### PR TITLE
(bootstrap 5) llab: prefetch URLs for performance

### DIFF
--- a/llab/loader.js
+++ b/llab/loader.js
@@ -4,7 +4,7 @@
  */
 
 const THIS_FILE = 'loader.js';
-const RELEASE_DATE = '2025-12-23';
+const RELEASE_DATE = '2026-05-28';
 
 // Basic llab shape.
 llab = {
@@ -44,6 +44,13 @@ llab.GAurl = location.origin;
 
 // Error Handling -- The URL embeds the Sentry desination
 llab.SENTRY_URL = 'https://js.sentry-cdn.com/f55a4cd65a8b48fd99e8247c6a5e6c2d.min.js';
+
+// Third-party origins we contact during page load. Pre-warming the
+// connection (DNS + TLS) shaves time off the first request to each.
+llab.PRECONNECT_ORIGINS = [
+    'https://www.googletagmanager.com',
+    'https://js.sentry-cdn.com',
+];
 
 // CSS, relative to llab/
 llab.paths.css_files = [
@@ -140,7 +147,7 @@ function getTag(name, src, type, opts) {
         src += `?${RELEASE_DATE}`;
     }
     tag[link] = src;
-    tag.type = type;
+    if (type) { tag.type = type; }
     if (opts) {
         for (let opt in opts) {
             tag[opt] = opts[opt];
@@ -154,8 +161,40 @@ function getTag(name, src, type, opts) {
 // Array.from(document.scripts).map(node => node.src.replace(location.origin, '').replace(/?.*$/, ''))
 // Array.from(document.styleSheets).map(node => node.src.replace(location.origin, '').replace(/\?.*$/, ''))
 // TODO - will need to normalize paths.
-llab.scriptTag = (src, onload) => getTag('script', src, 'text/javascript', { 'onload': onload });
+// async=false keeps execution order (jQuery before bootstrap, etc.) while
+// still letting the browser fetch every script in parallel.
+llab.scriptTag = (src, onload) => getTag('script', src, 'text/javascript', { 'onload': onload, 'async': false });
 llab.styleTag = (href) => getTag('link', href, 'text/css', { 'rel': 'stylesheet' });
+
+// Resource hints. Inserted up front so the preload scanner can kick off
+// downloads while stage 0 is still booting.
+llab.preloadTag = (href, as) => getTag('link', href, null, { 'rel': 'preload', 'as': as });
+// No crossorigin: the actual GA/Sentry script loads aren't CORS, so a
+// crossorigin preconnect wouldn't be reused for them.
+llab.preconnectTag = (href) => {
+    let tag = document.createElement('link');
+    tag.rel = 'preconnect';
+    tag.href = href;
+    return tag;
+};
+
+// Walk the staged-script config and emit one <link rel=preload> per file so
+// they all start downloading immediately, even though they execute in stages.
+llab.emitResourceHints = function() {
+    llab.PRECONNECT_ORIGINS.forEach(origin => {
+        document.head.appendChild(llab.preconnectTag(origin));
+    });
+
+    llab.paths.css_files.forEach(file => {
+        document.head.appendChild(llab.preloadTag(file, 'style'));
+    });
+
+    llab.paths.scripts.forEach(stage => {
+        stage.forEach(src => {
+            document.head.appendChild(llab.preloadTag(src, 'script'));
+        });
+    });
+};
 
 
 llab.initialSetUp = function() {
@@ -183,6 +222,8 @@ llab.initialSetUp = function() {
             setTimeout(() => { proceedWhenComplete(stage_num) }, 2);
         }
     }
+
+    llab.emitResourceHints();
 
     llab.paths.css_files.forEach(file => document.head.appendChild(llab.styleTag(file)));
     loadScriptsAndLinks(0);

--- a/llab/loader.js
+++ b/llab/loader.js
@@ -198,9 +198,19 @@ llab.emitResourceHints = function() {
 
 
 llab.initialSetUp = function() {
+    // Tracks stages we've already advanced past so onload + fallback polling
+    // can both fire safely without double-loading the next stage.
+    let advancedFromStage = new Set();
+
     let loadScriptsAndLinks = (stage_num) => {
         llab.paths.scripts[stage_num].forEach(src => {
-            document.head.appendChild(llab.scriptTag(src), () => proceedWhenComplete(stage_num));
+            // Pass the onload through scriptTag (via getTag's opts) so the
+            // script actually notifies us when it has executed. The previous
+            // form passed the callback as appendChild's second arg, which DOM
+            // ignores — that's why this loader relied on a 2ms polling loop.
+            document.head.appendChild(
+                llab.scriptTag(src, () => proceedWhenComplete(stage_num))
+            );
         });
 
         // loading optional stuff after jQuery/Bootstrap dependencies, but early as possible.
@@ -214,12 +224,18 @@ llab.initialSetUp = function() {
     }
 
     proceedWhenComplete = (stage_num) => {
+        if (advancedFromStage.has(stage_num)) { return; }
         if (llab.paths.stage_complete_functions[stage_num]()) {
+            advancedFromStage.add(stage_num);
             if ((stage_num + 1) < llab.paths.scripts.length) {
                 loadScriptsAndLinks(stage_num + 1);
             }
         } else {
-            setTimeout(() => { proceedWhenComplete(stage_num) }, 2);
+            // Fallback: onload is the primary signal, but we keep a slow poll
+            // in case a stage's `llab.loaded` flag is set after onload (e.g.,
+            // a script that defers its ready state via a microtask). 50ms is
+            // a soft heartbeat — it's harmless once onload has already fired.
+            setTimeout(() => { proceedWhenComplete(stage_num) }, 50);
         }
     }
 

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -505,6 +505,20 @@ llab.isCurriculum = () => llab.getQueryParameter('topic') != "" && !llab.isTopic
 * they could become re-ordered. */
 llab.thisPageNum = () => llab.pageNum;
 
+// Hint the browser to fetch a likely-next URL so a click resolves from cache.
+// Same-origin only — we don't want to warm third-party links.
+llab.prefetched_urls = llab.prefetched_urls || new Set();
+llab.prefetchPage = function(url) {
+  if (!url || llab.prefetched_urls.has(url)) { return; }
+  if (url.indexOf('//') !== -1 && url.indexOf(location.origin) !== 0) { return; }
+  llab.prefetched_urls.add(url);
+  let tag = document.createElement('link');
+  tag.rel = 'prefetch';
+  tag.href = url;
+  tag.as = 'document';
+  document.head.appendChild(tag);
+};
+
 // Create the Forward and Backward buttons, properly disabling them when needed
 llab.setButtonURLs = function() {
   // No dropdowns for places that don't have a step.
@@ -525,20 +539,24 @@ llab.setButtonURLs = function() {
   if (llab.thisPageNum() === 0) {
     back.addClass('disabled').removeAttr('href').removeAttr('aria-label').attr('disabled', true);
   } else {
+    let prevURL = llab.url_list[llab.thisPageNum() - 1];
     back.removeClass('disabled').removeAttr('disabled')
       .attr('aria-label', llab.t('backText'))
-      .attr('href', llab.url_list[llab.thisPageNum() - 1])
-      .on('click', llab.dynamicNavigation(llab.url_list[llab.thisPageNum() - 1]));
+      .attr('href', prevURL)
+      .on('click', llab.dynamicNavigation(prevURL));
+    llab.prefetchPage(prevURL);
   }
 
   // Disable the forward button
   if (llab.thisPageNum() === llab.url_list.length - 1) {
     forward.addClass('disabled').removeAttr('href').removeAttr('aria-label').attr('disabled', true);
   } else {
+    let nextURL = llab.url_list[llab.thisPageNum() + 1];
     forward.removeClass('disabled').removeAttr('disabled')
       .attr('aria-label', llab.t('nextText'))
-      .attr('href', llab.url_list[llab.thisPageNum() + 1])
-      .on('click', llab.dynamicNavigation(llab.url_list[llab.thisPageNum() + 1]));
+      .attr('href', nextURL)
+      .on('click', llab.dynamicNavigation(nextURL));
+    llab.prefetchPage(nextURL);
   }
 };
 

--- a/llab/script/quiz/multiplechoice.js
+++ b/llab/script/quiz/multiplechoice.js
@@ -129,6 +129,21 @@ MC.prototype.render = function() {
         if (this.content.additonal_info) {
             this.multipleChoice.find('.questionType').append(this.content.additonal_info);
         }
+
+        // Bind the shared Check/Try-Again buttons exactly once per MC. They live
+        // on the question, not on individual choices, so binding inside the
+        // per-choice loop attached one handler per choice (4 choices => 4× fire).
+        this.multipleChoice.find(".checkAnswerButton").bind('click', {
+            myQuestion: this
+        }, function(args) {
+            args.data.myQuestion.checkAnswer();
+        });
+
+        this.multipleChoice.find(".tryAgainButton").bind('click', {
+            myQuestion: this
+        }, function(args) {
+            args.data.myQuestion.tryAgain();
+        });
     }
 
     /* render the prompt */
@@ -175,18 +190,6 @@ MC.prototype.render = function() {
         if (this.selectedInSavedState(optId)) {
             $(`#${choice_id}`).attr('checked', true);
         }
-
-        this.multipleChoice.find(".checkAnswerButton").bind('click', {
-            myQuestion: this
-        }, function(args) {
-            args.data.myQuestion.checkAnswer();
-        });
-
-        this.multipleChoice.find(".tryAgainButton").bind('click', {
-            myQuestion: this
-        }, function(args) {
-            args.data.myQuestion.tryAgain();
-        });
     }
 
     this.multipleChoice.find('.tryAgainButton').addClass('disabled').attr('disabled', true);


### PR DESCRIPTION
## Improve rendering and navigation performance without a build system

Reduces flash-of-content and navigation latency by enabling parallel asset downloads and prefetching likely-next pages — all without requiring a build step.

## Changes

- **Resource hints on load** — `emitResourceHints()` injects `<link rel=preload>` for all CSS and JS assets (across all stages) plus `<link rel=preconnect>` for Google Tag Manager and Sentry before any scripts execute, letting the browser fetch everything in parallel while stage 0 boots
- **Parallel script fetching** — sets `async = false` on dynamically inserted scripts so they download in parallel while still executing in the correct order (jQuery → Bootstrap → quiz, etc.)
- **Curriculum page prefetching** — `setButtonURLs` now emits `<link rel=prefetch as=document>` for the previous and next page URLs, so the most likely next navigation resolves from cache; same-origin only to avoid warming third-party links
- **`RELEASE_DATE` bump** — updated to ensure preload `?date` query params and actual asset requests share the same cache key

### What this doesn't fix
The residual flash where the JS-built navbar materializes after `$(document).ready` requires moving the navbar skeleton into HTML — that's a separate, larger change.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/McpTTMH9LBFG/implementations/pzThFdh8J9qF) | [App Preview](https://www.superconductor.com/tickets/McpTTMH9LBFG/implementations/pzThFdh8J9qF/preview) | [Guided Review](https://www.superconductor.com/tickets/McpTTMH9LBFG/implementations/pzThFdh8J9qF?tab=guided_review)

<!-- created-by-superconductor -->