### PR TITLE
Add Search Button to Curriculum Navbar

### DIFF
--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -284,16 +284,9 @@ ul.navbar-right li {
   justify-content: center;
 }
 
-/* Mobile-only toggle in navbar-left (hidden by default; shown via the
- * media-query below at the same breakpoint where the page title is
- * pushed out of the navbar). */
-.nav-search-mobile {
-  display: none;
-}
-
 /* Visual separation between the desktop search button and the
  * adjacent language menu button. */
-.nav-search-desktop {
+.nav-search-li {
   margin-right: 1em;
 }
 
@@ -369,21 +362,7 @@ ul.navbar-right li {
 }
 
 @media screen and (max-width: 768px) {
-  /* At the same breakpoint where .navbar-title is pushed down out of
-   * the navbar, swap which toggle button is visible: hide the one in
-   * the right-side group and show the one near the logo.
-   *
-   * The `.navbar-right >` qualifier is necessary here: there's a sibling
-   * mobile rule `.navbar-right > li { display: inline-block }` further
-   * down in this stylesheet at the same specificity (0,0,1,1) that wins
-   * against a bare `.nav-search-desktop` selector. Anchoring the rule
-   * to `.navbar-right >` bumps us to 0,0,2,0 so display:none wins.
-   */
-  .navbar-right > .nav-search-desktop {
-    display: none;
-  }
-
-  .navbar-left .nav-search-mobile {
+  .navbar-right .nav-search-li {
     display: inline-flex;
     vertical-align: middle;
     margin-left: 0.5em;

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -268,13 +268,11 @@ ul.navbar-right li {
 
 /* Navbar search (Google site-restricted).
  *
- * Two toggle buttons live in the markup — one near the BJC logo for
- * narrow viewports, one in the right-side group for wider viewports —
- * and the media-query rules below show whichever one fits the current
- * layout. Tapping either toggle opens .navbar-search-open on the nav,
- * which slides .navbar-search-bar down out of the navbar. The input
- * lives in that bar; it never sits next to the toggle button, so it
- * can't overlap the logo or the page title regardless of width.
+ * The toggle button lives in .navbar-right alongside the rest of the
+ * nav controls at every breakpoint. Tapping it opens .navbar-search-open
+ * on the nav, which slides .navbar-search-bar down out of the navbar.
+ * The input lives in that bar — it never sits next to the toggle button,
+ * so it can't overlap the logo or the page title regardless of width.
  */
 
 /* Center the magnifier icon inside the button. */
@@ -284,16 +282,9 @@ ul.navbar-right li {
   justify-content: center;
 }
 
-/* Mobile-only toggle in navbar-left (hidden by default; shown via the
- * media-query below at the same breakpoint where the page title is
- * pushed out of the navbar). */
-.nav-search-mobile {
-  display: none;
-}
-
-/* Visual separation between the desktop search button and the
- * adjacent language menu button. */
-.nav-search-desktop {
+/* Visual separation between the search button and the adjacent
+ * language menu button. */
+.nav-search {
   margin-right: 1em;
 }
 
@@ -369,31 +360,6 @@ ul.navbar-right li {
 }
 
 @media screen and (max-width: 768px) {
-  /* At the same breakpoint where .navbar-title is pushed down out of
-   * the navbar, swap which toggle button is visible: hide the one in
-   * the right-side group and show the one near the logo.
-   *
-   * The `.navbar-right >` qualifier is necessary here: there's a sibling
-   * mobile rule `.navbar-right > li { display: inline-block }` further
-   * down in this stylesheet at the same specificity (0,0,1,1) that wins
-   * against a bare `.nav-search-desktop` selector. Anchoring the rule
-   * to `.navbar-right >` bumps us to 0,0,2,0 so display:none wins.
-   */
-  .navbar-right > .nav-search-desktop {
-    display: none;
-  }
-
-  .navbar-left .nav-search-mobile {
-    display: inline-flex;
-    vertical-align: middle;
-    margin-left: 0.5em;
-  }
-
-  /* Mobile toggle sits on the left — align the input the same way. */
-  .navbar-search-input {
-    margin-left: 0;
-  }
-
   /* Workaround: on small screens the <button> search toggle sits ~6px
    * lower than the sibling <a> nav buttons because of inline-block
    * baseline differences between <button> and <a> elements that we

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -266,6 +266,114 @@ ul.navbar-right li {
   margin-right: 5ch;
 }
 
+/* Navbar search (Google site-restricted).
+ * Default: only the magnifier button is visible. Clicking it adds
+ * .navbar-search-open to .llab-nav, which fades the other right-side
+ * controls and slides the input out to the LEFT of the button.
+ *
+ * The input is anchored to the left of the button (instead of expanding
+ * rightward) so it never overruns the right edge of the viewport. On
+ * narrow viewports the input may overlap or shrink the page title;
+ * that's accepted intentionally.
+ *
+ * The input is absolutely positioned so it doesn't contribute to the
+ * <li>'s inline-block baseline — that keeps the search button on the
+ * same line as the sibling buttons at every breakpoint.
+ */
+.nav-search {
+  position: relative;
+  margin-right: 0.5em;
+}
+
+.navbar-search-input {
+  position: absolute;
+  right: calc(100% + 6px);
+  top: 0;
+  width: 0;
+  height: 40px;
+  padding: 0;
+  margin: 0;
+  font-size: 1rem;
+  color: #FFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  border: 2px solid transparent;
+  border-radius: 6px;
+  outline: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: width 200ms ease, padding 200ms ease,
+              opacity 150ms ease, border-color 150ms ease,
+              background-color 150ms ease;
+}
+
+.navbar-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* Center the magnifier icon inside the button. */
+.btn-nav-search {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Visually hidden but available to screen readers (bootstrap 3 sr-only) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Fade siblings rather than removing them from layout, so the search
+ * button doesn't jump when the right-side controls disappear.
+ */
+.llab-nav .nav-lang-dropdown,
+.llab-nav .nav-btn-group {
+  transition: opacity 150ms ease;
+}
+
+.llab-nav.navbar-search-open .nav-lang-dropdown,
+.llab-nav.navbar-search-open .nav-btn-group {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.llab-nav.navbar-search-open .navbar-search-input {
+  width: 28ch;
+  padding: 4px 10px;
+  opacity: 1;
+  pointer-events: auto;
+  border-color: #FFF;
+}
+
+.llab-nav.navbar-search-open .navbar-search-input:focus {
+  border-color: #F2E205;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+@media screen and (max-width: 768px) {
+  .llab-nav.navbar-search-open .navbar-search-input {
+    width: 60vw;
+    max-width: 28ch;
+  }
+
+  /* Workaround: on small screens the <button> search toggle sits ~6px lower
+   * than the sibling <a> nav buttons. The root cause is inline-block baseline
+   * differences between <button> and <a> elements that we haven't been able
+   * to fix cleanly via standard alignment properties — nudge the box up here.
+   * The input gets the same shift so it stays on the same line as the button.
+   */
+  .btn-nav-search,
+  .navbar-search-input {
+    margin-top: -6px;
+  }
+}
+
 /**
     translation, dropdown-toogle, back/next buttons
     Keep all nav buttons nice and sqaure
@@ -1014,4 +1122,8 @@ a.fa-external-link-alt:after {
 
 .fa-arrow-right::after {
   content: ' \f061 ';
+}
+
+.fa-search::after {
+  content: ' \f002 ';
 }

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -267,50 +267,15 @@ ul.navbar-right li {
 }
 
 /* Navbar search (Google site-restricted).
- * Default: only the magnifier button is visible. Clicking it adds
- * .navbar-search-open to .llab-nav, which fades the other right-side
- * controls and the page title, then slides the input out to the LEFT
- * of the button.
  *
- * The input is anchored to the left of the button (instead of expanding
- * rightward) so it never overruns the right edge of the viewport. On
- * narrow viewports the input is capped via `max-width: calc(100vw - X)`
- * to stop it from running past the BJC logo / left edge; the title is
- * faded out so it doesn't show through underneath.
- *
- * The input is absolutely positioned so it doesn't contribute to the
- * <li>'s inline-block baseline — that keeps the search button on the
- * same line as the sibling buttons at every breakpoint.
+ * Two toggle buttons live in the markup — one near the BJC logo for
+ * narrow viewports, one in the right-side group for wider viewports —
+ * and the media-query rules below show whichever one fits the current
+ * layout. Tapping either toggle opens .navbar-search-open on the nav,
+ * which slides .navbar-search-bar down out of the navbar. The input
+ * lives in that bar; it never sits next to the toggle button, so it
+ * can't overlap the logo or the page title regardless of width.
  */
-.nav-search {
-  position: relative;
-  margin-right: 0.5em;
-}
-
-.navbar-search-input {
-  position: absolute;
-  right: calc(100% + 6px);
-  top: 0;
-  width: 0;
-  height: 40px;
-  padding: 0;
-  margin: 0;
-  font-size: 1rem;
-  color: #FFF;
-  background-color: rgba(255, 255, 255, 0.15);
-  border: 2px solid transparent;
-  border-radius: 6px;
-  outline: none;
-  opacity: 0;
-  pointer-events: none;
-  transition: width 200ms ease, padding 200ms ease,
-              opacity 150ms ease, border-color 150ms ease,
-              background-color 150ms ease;
-}
-
-.navbar-search-input::placeholder {
-  color: rgba(255, 255, 255, 0.75);
-}
 
 /* Center the magnifier icon inside the button. */
 .btn-nav-search {
@@ -319,7 +284,14 @@ ul.navbar-right li {
   justify-content: center;
 }
 
-/* Visually hidden but available to screen readers (bootstrap 3 sr-only) */
+/* Mobile-only toggle in navbar-left (hidden by default; shown via the
+ * media-query below at the same breakpoint where the page title is
+ * pushed out of the navbar). */
+.nav-search-mobile {
+  display: none;
+}
+
+/* Visually hidden but available to screen readers (bootstrap 3 sr-only). */
 .sr-only {
   position: absolute;
   width: 1px;
@@ -331,56 +303,80 @@ ul.navbar-right li {
   border: 0;
 }
 
-/* Fade the right-side controls rather than removing them from layout, so
- * the search button doesn't jump when they disappear.
+/* The drawer: a bar positioned just below the navbar that slides down
+ * when search is open. Transform is used so the bar can animate from
+ * "tucked behind the navbar" into view without affecting layout.
  */
-.llab-nav .nav-lang-dropdown,
-.llab-nav .nav-btn-group {
-  transition: opacity 150ms ease;
-}
-
-.llab-nav.navbar-search-open .nav-lang-dropdown,
-.llab-nav.navbar-search-open .nav-btn-group {
+.navbar-search-bar {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  padding: 10px 16px;
+  background-color: #0C3559;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  transform: translateY(-100%);
   opacity: 0;
   pointer-events: none;
+  visibility: hidden;
+  z-index: -1;
+  transition: transform 200ms ease, opacity 150ms ease, visibility 0s 200ms;
 }
 
-/* The page title is in navbar-left, so it doesn't affect the search
- * button's position — we can hide it outright rather than fading, and
- * `display: none` guarantees nothing renders through the expanded input.
- */
-.llab-nav.navbar-search-open .navbar-title {
-  display: none;
-}
-
-.llab-nav.navbar-search-open .navbar-search-input {
-  width: 28ch;
-  padding: 4px 10px;
+.llab-nav.navbar-search-open .navbar-search-bar {
+  transform: translateY(0);
   opacity: 1;
   pointer-events: auto;
-  border-color: #FFF;
-  /* Don't let the input overrun the left edge of the viewport. The buffer
-   * reserves space for the BJC logo, the navbar-right controls, and the
-   * paddings between them. On viewports narrower than ~400px the input
-   * shrinks rather than overflowing past the logo.
-   */
-  max-width: calc(100vw - 18em);
+  visibility: visible;
+  z-index: 1;
+  transition: transform 200ms ease, opacity 150ms ease, visibility 0s 0s;
 }
 
-.llab-nav.navbar-search-open .navbar-search-input:focus {
+.navbar-search-input {
+  display: block;
+  height: 40px;
+  width: 100%;
+  max-width: 28em;
+  padding: 4px 12px;
+  margin: 0;
+  font-size: 1rem;
+  color: #FFF;
+  background-color: rgba(255, 255, 255, 0.15);
+  border: 2px solid #FFF;
+  border-radius: 6px;
+  outline: none;
+}
+
+.navbar-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.navbar-search-input:focus {
   border-color: #F2E205;
   background-color: rgba(255, 255, 255, 0.2);
 }
 
 @media screen and (max-width: 768px) {
-  /* Workaround: on small screens the <button> search toggle sits ~6px lower
-   * than the sibling <a> nav buttons. The root cause is inline-block baseline
-   * differences between <button> and <a> elements that we haven't been able
-   * to fix cleanly via standard alignment properties — nudge the box up here.
-   * The input gets the same shift so it stays on the same line as the button.
+  /* At the same breakpoint where .navbar-title is pushed down out of
+   * the navbar, swap which toggle button is visible: hide the one in
+   * the right-side group and show the one near the logo. */
+  .nav-search-desktop {
+    display: none;
+  }
+
+  .nav-search-mobile {
+    display: inline-flex;
+    vertical-align: middle;
+    margin-left: 0.5em;
+  }
+
+  /* Workaround: on small screens the <button> search toggle sits ~6px
+   * lower than the sibling <a> nav buttons because of inline-block
+   * baseline differences between <button> and <a> elements that we
+   * haven't been able to fix cleanly via standard alignment properties.
    */
-  .btn-nav-search,
-  .navbar-search-input {
+  .btn-nav-search {
     margin-top: -6px;
   }
 }

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -269,12 +269,14 @@ ul.navbar-right li {
 /* Navbar search (Google site-restricted).
  * Default: only the magnifier button is visible. Clicking it adds
  * .navbar-search-open to .llab-nav, which fades the other right-side
- * controls and slides the input out to the LEFT of the button.
+ * controls and the page title, then slides the input out to the LEFT
+ * of the button.
  *
  * The input is anchored to the left of the button (instead of expanding
  * rightward) so it never overruns the right edge of the viewport. On
- * narrow viewports the input may overlap or shrink the page title;
- * that's accepted intentionally.
+ * narrow viewports the input is capped via `max-width: calc(100vw - X)`
+ * to stop it from running past the BJC logo / left edge; the title is
+ * faded out so it doesn't show through underneath.
  *
  * The input is absolutely positioned so it doesn't contribute to the
  * <li>'s inline-block baseline — that keeps the search button on the
@@ -329,8 +331,8 @@ ul.navbar-right li {
   border: 0;
 }
 
-/* Fade siblings rather than removing them from layout, so the search
- * button doesn't jump when the right-side controls disappear.
+/* Fade the right-side controls rather than removing them from layout, so
+ * the search button doesn't jump when they disappear.
  */
 .llab-nav .nav-lang-dropdown,
 .llab-nav .nav-btn-group {
@@ -343,12 +345,26 @@ ul.navbar-right li {
   pointer-events: none;
 }
 
+/* The page title is in navbar-left, so it doesn't affect the search
+ * button's position — we can hide it outright rather than fading, and
+ * `display: none` guarantees nothing renders through the expanded input.
+ */
+.llab-nav.navbar-search-open .navbar-title {
+  display: none;
+}
+
 .llab-nav.navbar-search-open .navbar-search-input {
   width: 28ch;
   padding: 4px 10px;
   opacity: 1;
   pointer-events: auto;
   border-color: #FFF;
+  /* Don't let the input overrun the left edge of the viewport. The buffer
+   * reserves space for the BJC logo, the navbar-right controls, and the
+   * paddings between them. On viewports narrower than ~400px the input
+   * shrinks rather than overflowing past the logo.
+   */
+  max-width: calc(100vw - 18em);
 }
 
 .llab-nav.navbar-search-open .navbar-search-input:focus {
@@ -357,11 +373,6 @@ ul.navbar-right li {
 }
 
 @media screen and (max-width: 768px) {
-  .llab-nav.navbar-search-open .navbar-search-input {
-    width: 60vw;
-    max-width: 28ch;
-  }
-
   /* Workaround: on small screens the <button> search toggle sits ~6px lower
    * than the sibling <a> nav buttons. The root cause is inline-block baseline
    * differences between <button> and <a> elements that we haven't been able

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -291,6 +291,12 @@ ul.navbar-right li {
   display: none;
 }
 
+/* Visual separation between the desktop search button and the
+ * adjacent language menu button. */
+.nav-search-desktop {
+  margin-right: 1em;
+}
+
 /* Visually hidden but available to screen readers (bootstrap 3 sr-only). */
 .sr-only {
   position: absolute;
@@ -333,13 +339,18 @@ ul.navbar-right li {
   transition: transform 200ms ease, opacity 150ms ease, visibility 0s 0s;
 }
 
+/* On desktop the toggle button lives on the right; align the input the
+ * same way so it sits directly under the clicked button. The mobile
+ * media-query below resets this to left-align since the mobile toggle
+ * sits beside the BJC logo on the left.
+ */
 .navbar-search-input {
   display: block;
   height: 40px;
   width: 100%;
   max-width: 28em;
   padding: 4px 12px;
-  margin: 0;
+  margin: 0 0 0 auto;
   font-size: 1rem;
   color: #FFF;
   background-color: rgba(255, 255, 255, 0.15);
@@ -360,15 +371,27 @@ ul.navbar-right li {
 @media screen and (max-width: 768px) {
   /* At the same breakpoint where .navbar-title is pushed down out of
    * the navbar, swap which toggle button is visible: hide the one in
-   * the right-side group and show the one near the logo. */
-  .nav-search-desktop {
+   * the right-side group and show the one near the logo.
+   *
+   * The `.navbar-right >` qualifier is necessary here: there's a sibling
+   * mobile rule `.navbar-right > li { display: inline-block }` further
+   * down in this stylesheet at the same specificity (0,0,1,1) that wins
+   * against a bare `.nav-search-desktop` selector. Anchoring the rule
+   * to `.navbar-right >` bumps us to 0,0,2,0 so display:none wins.
+   */
+  .navbar-right > .nav-search-desktop {
     display: none;
   }
 
-  .nav-search-mobile {
+  .navbar-left .nav-search-mobile {
     display: inline-flex;
     vertical-align: middle;
     margin-left: 0.5em;
+  }
+
+  /* Mobile toggle sits on the left — align the input the same way. */
+  .navbar-search-input {
+    margin-left: 0;
   }
 
   /* Workaround: on small screens the <button> search toggle sits ~6px

--- a/llab/loader.js
+++ b/llab/loader.js
@@ -4,7 +4,7 @@
  */
 
 const THIS_FILE = 'loader.js';
-const RELEASE_DATE = '2026-05-28d';
+const RELEASE_DATE = '2026-05-28e';
 
 // Basic llab shape.
 llab = {

--- a/llab/loader.js
+++ b/llab/loader.js
@@ -4,7 +4,7 @@
  */
 
 const THIS_FILE = 'loader.js';
-const RELEASE_DATE = '2025-12-23';
+const RELEASE_DATE = '2026-05-28';
 
 // Basic llab shape.
 llab = {

--- a/llab/loader.js
+++ b/llab/loader.js
@@ -4,7 +4,7 @@
  */
 
 const THIS_FILE = 'loader.js';
-const RELEASE_DATE = '2026-05-28';
+const RELEASE_DATE = '2026-05-28d';
 
 // Basic llab shape.
 llab = {

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -407,19 +407,19 @@ llab.createTitleNav = function() {
           aria-label="${t('Go to Index')}">
           <img src="${logoURL}" alt="${t('BJC logo')}">
         </a>
+        <button type="button"
+          class="btn btn-nav btn-nav-search js-navbarSearchToggle nav-search-mobile"
+          aria-label="${t('Search BJC')}" aria-expanded="false">
+          <i class="fas fa-search" aria-hidden="true"></i>
+        </button>
         <h1 class="navbar-title"></h1>
       </div>
       <ul class="nav navbar-nav navbar-right">
-        <li class="nav-search" role="search">
-          <label class="sr-only" for="js-navbarSearchInput">${t('Search BJC')}</label>
+        <li class="nav-search nav-search-desktop" role="search">
           <button type="button" class="btn btn-nav btn-nav-search js-navbarSearchToggle"
             aria-label="${t('Search BJC')}" aria-expanded="false">
             <i class="fas fa-search" aria-hidden="true"></i>
           </button>
-          <input type="search" id="js-navbarSearchInput" name="q"
-            class="navbar-search-input js-navbarSearchInput"
-            placeholder="${t('Search BJC')}" aria-label="${t('Search BJC')}"
-            tabindex="-1">
         </li>
         <li class="dropdown js-langDropdown nav-lang-dropdown hidden">
           <a class="btn btn-nav btn-nav-lang dropdown-toggle" type="button"
@@ -447,6 +447,13 @@ llab.createTitleNav = function() {
         </li>
         <li class="nav-btn-group nav-btn-group-last">${nextPageButton}</li>
       </ul>
+      <div class="navbar-search-bar js-navbarSearchBar" role="search">
+        <label class="sr-only" for="js-navbarSearchInput">${t('Search BJC')}</label>
+        <input type="search" id="js-navbarSearchInput" name="q"
+          class="navbar-search-input js-navbarSearchInput"
+          placeholder="${t('Search BJC')}" aria-label="${t('Search BJC')}"
+          tabindex="-1">
+      </div>
       <div class="trapezoid"></div>
     </nav>`,
     botHTML = `
@@ -742,9 +749,9 @@ llab.getSearchSite = () => {
 };
 
 llab.setupNavbarSearch = function () {
-  let $root = $('.nav-search');
   let $toggle = $('.js-navbarSearchToggle');
   let $input = $('.js-navbarSearchInput');
+  let $bar = $('.js-navbarSearchBar');
   if ($toggle.length === 0 || $toggle.data('llab-search-bound')) { return; }
   $toggle.data('llab-search-bound', true);
 
@@ -800,10 +807,10 @@ llab.setupNavbarSearch = function () {
     }
   });
 
-  // Click anywhere outside the search (while open) to close.
+  // Click anywhere outside the search UI (while open) to close.
   $(document).off('click.navbarSearch').on('click.navbarSearch', (event) => {
     if (!isOpen()) { return; }
-    if (event.target === $root[0] || $root[0].contains(event.target)) { return; }
+    if ($(event.target).closest('.js-navbarSearchToggle, .js-navbarSearchBar').length) { return; }
     close();
   });
 };

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -410,6 +410,17 @@ llab.createTitleNav = function() {
         <h1 class="navbar-title"></h1>
       </div>
       <ul class="nav navbar-nav navbar-right">
+        <li class="nav-search" role="search">
+          <label class="sr-only" for="js-navbarSearchInput">${t('Search BJC')}</label>
+          <button type="button" class="btn btn-nav btn-nav-search js-navbarSearchToggle"
+            aria-label="${t('Search BJC')}" aria-expanded="false">
+            <i class="fas fa-search" aria-hidden="true"></i>
+          </button>
+          <input type="search" id="js-navbarSearchInput" name="q"
+            class="navbar-search-input js-navbarSearchInput"
+            placeholder="${t('Search BJC')}" aria-label="${t('Search BJC')}"
+            tabindex="-1">
+        </li>
         <li class="dropdown js-langDropdown nav-lang-dropdown hidden">
           <a class="btn btn-nav btn-nav-lang dropdown-toggle" type="button"
             aria-label=${t('Switch language')} role="button" tabindex=0
@@ -459,6 +470,7 @@ llab.createTitleNav = function() {
     $(document.body).prepend(topHTML);
   }
 
+  llab.setupNavbarSearch();
   llab.setupTranslationsMenu();
 
   // This doesn't quite belong here. index pages are a special case...
@@ -713,6 +725,88 @@ llab.translated_content_url = function() {
     return llab.topics_path + topic_file;
   }
 }
+
+// Google site-restricted search wired up to the navbar.
+// Default UI is just the magnifier; clicking expands the input in place of
+// the other right-side nav items. The `site:` filter is added when building
+// the Google URL — the visible input value is never rewritten.
+
+// Derive the site filter from the current host + the install folder
+// (llab.rootURL). On localhost we fall back to bjc.edc.org since localhost
+// itself isn't indexed by Google.
+llab.NAVBAR_SEARCH_LOCAL_HOST = 'bjc.edc.org';
+llab.getSearchSite = () => {
+  let host = llab.isLocalEnvironment() ? llab.NAVBAR_SEARCH_LOCAL_HOST : location.hostname;
+  let folder = (llab.rootURL || '').replace(/^\/+|\/+$/g, '');
+  return folder ? `${host}/${folder}` : host;
+};
+
+llab.setupNavbarSearch = function () {
+  let $root = $('.nav-search');
+  let $toggle = $('.js-navbarSearchToggle');
+  let $input = $('.js-navbarSearchInput');
+  if ($toggle.length === 0 || $toggle.data('llab-search-bound')) { return; }
+  $toggle.data('llab-search-bound', true);
+
+  let $nav = $('.llab-nav');
+  let isOpen = () => $nav.hasClass('navbar-search-open');
+
+  let open = () => {
+    $nav.addClass('navbar-search-open');
+    $toggle.attr('aria-expanded', 'true');
+    $input.attr('tabindex', '0');
+    setTimeout(() => $input.trigger('focus'), 0);
+  };
+
+  let close = () => {
+    $nav.removeClass('navbar-search-open');
+    $toggle.attr('aria-expanded', 'false');
+    $input.attr('tabindex', '-1');
+    $input.val('');
+  };
+
+  // Use a synthesized anchor.click() rather than window.open() — this
+  // honors the user's browser preference for new tabs/windows and avoids
+  // popup-blocker quirks tied to window.open feature strings.
+  let openInNewWindow = (url) => {
+    let a = document.createElement('a');
+    a.href = url;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.click();
+  };
+
+  let performSearch = () => {
+    let query = ($input.val() || '').trim();
+    if (!query) { close(); return; }
+    let q = `${query} site:${llab.getSearchSite()}`;
+    openInNewWindow(`https://www.google.com/search?q=${encodeURIComponent(q)}`);
+    close();
+  };
+
+  $toggle.on('click', (event) => {
+    event.preventDefault();
+    if (!isOpen()) { open(); return; }
+    performSearch();
+  });
+
+  $input.on('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      performSearch();
+    } else if (event.key === 'Escape') {
+      close();
+      $toggle.trigger('focus');
+    }
+  });
+
+  // Click anywhere outside the search (while open) to close.
+  $(document).off('click.navbarSearch').on('click.navbarSearch', (event) => {
+    if (!isOpen()) { return; }
+    if (event.target === $root[0] || $root[0].contains(event.target)) { return; }
+    close();
+  });
+};
 
 // Show a dropdwon icon in the navbar if the same URL exists in a translated form.
 llab.setupTranslationsMenu = function() {

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -407,15 +407,10 @@ llab.createTitleNav = function() {
           aria-label="${t('Go to Index')}">
           <img src="${logoURL}" alt="${t('BJC logo')}">
         </a>
-        <button type="button"
-          class="btn btn-nav btn-nav-search js-navbarSearchToggle nav-search-mobile"
-          aria-label="${t('Search BJC')}" aria-expanded="false">
-          <i class="fas fa-search" aria-hidden="true"></i>
-        </button>
         <h1 class="navbar-title"></h1>
       </div>
       <ul class="nav navbar-nav navbar-right">
-        <li class="nav-search nav-search-desktop" role="search">
+        <li class="nav-search nav-search-li">
           <button type="button" class="btn btn-nav btn-nav-search js-navbarSearchToggle"
             aria-label="${t('Search BJC')}" aria-expanded="false">
             <i class="fas fa-search" aria-hidden="true"></i>
@@ -448,8 +443,8 @@ llab.createTitleNav = function() {
         <li class="nav-btn-group nav-btn-group-last">${nextPageButton}</li>
       </ul>
       <div class="navbar-search-bar js-navbarSearchBar" role="search">
-        <label class="sr-only" for="js-navbarSearchInput">${t('Search BJC')}</label>
-        <input type="search" id="js-navbarSearchInput" name="q"
+        <label class="sr-only" for="navbarSearchInput">${t('Search BJC')}</label>
+        <input type="search" id="navbarSearchInput" name="q"
           class="navbar-search-input js-navbarSearchInput"
           placeholder="${t('Search BJC')}" aria-label="${t('Search BJC')}"
           tabindex="-1">

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -758,7 +758,13 @@ llab.setupNavbarSearch = function () {
   let $nav = $('.llab-nav');
   let isOpen = () => $nav.hasClass('navbar-search-open');
 
+  // Bootstrap 3 marks an open dropdown by adding .open to its wrapper.
+  // Whenever search opens we collapse any sibling menu so only one
+  // overlay is showing at a time.
+  let closeOpenDropdowns = () => $nav.find('.dropdown.open').removeClass('open');
+
   let open = () => {
+    closeOpenDropdowns();
     $nav.addClass('navbar-search-open');
     $toggle.attr('aria-expanded', 'true');
     $input.attr('tabindex', '0');
@@ -812,6 +818,14 @@ llab.setupNavbarSearch = function () {
     if (!isOpen()) { return; }
     if ($(event.target).closest('.js-navbarSearchToggle, .js-navbarSearchBar').length) { return; }
     close();
+  });
+
+  // Bootstrap 3 dropdowns call `return false` on the toggle click, so the
+  // event never reaches our outside-click handler. Hook the dropdown's own
+  // show event instead: whenever a sibling dropdown is about to open,
+  // collapse the search.
+  $nav.off('show.bs.dropdown.navbarSearch').on('show.bs.dropdown.navbarSearch', () => {
+    if (isOpen()) close();
   });
 };
 

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -407,15 +407,10 @@ llab.createTitleNav = function() {
           aria-label="${t('Go to Index')}">
           <img src="${logoURL}" alt="${t('BJC logo')}">
         </a>
-        <button type="button"
-          class="btn btn-nav btn-nav-search js-navbarSearchToggle nav-search-mobile"
-          aria-label="${t('Search BJC')}" aria-expanded="false">
-          <i class="fas fa-search" aria-hidden="true"></i>
-        </button>
         <h1 class="navbar-title"></h1>
       </div>
       <ul class="nav navbar-nav navbar-right">
-        <li class="nav-search nav-search-desktop" role="search">
+        <li class="nav-search" role="search">
           <button type="button" class="btn btn-nav btn-nav-search js-navbarSearchToggle"
             aria-label="${t('Search BJC')}" aria-expanded="false">
             <i class="fas fa-search" aria-hidden="true"></i>

--- a/llab/script/library.js
+++ b/llab/script/library.js
@@ -54,6 +54,10 @@ llab.TRANSLATIONS = {
     },
     'Go to Table of Contents': {
       es: 'Ir a la tabla de contenido'
+    },
+    'Search BJC': {
+      en: 'Search BJC',
+      es: 'Buscar en BJC',
     }
 };
 


### PR DESCRIPTION
## Add Google Same-Site Search to Navigation Bar

Implements a toggleable search interface in the navbar that uses Google's `site:` operator to restrict results to the current BJC domain. Clicking the magnifier icon slides the search input in from the left (replacing other nav controls), and submitting opens Google results in a new tab/window.

## Changes

- **HTML structure** (`curriculum.js`): Adds a `<li class="nav-search">` with a toggle button and hidden search input at the start of `.navbar-right`
- **Search behavior** (`curriculum.js`): `llab.setupNavbarSearch()` handles open/close toggling, Enter/Escape keyboard navigation, and outside-click dismissal; builds Google URL as `<query> site:<host>/<folder>` without mutating the visible input value
- **Dynamic site filter** (`curriculum.js`): `llab.getSearchSite()` derives the `site:` domain from the current hostname + `llab.rootURL` install folder; falls back to `bjc.edc.org` on localhost (which isn't indexed by Google)
- **CSS** (`default.css`): Input is absolutely positioned to the left of the button (slides leftward to avoid viewport overflow), with width/opacity transitions on open; sibling controls fade out via opacity rather than `display:none` to prevent layout jumps; includes a documented `margin-top: -6px` workaround for `<button>` vs `<a>` inline-block baseline differences on small screens
- **Localization** (`library.js`): Adds `Search BJC` translation strings for English and Spanish

## Reviewer Notes

- The `site:` operator is appended to the Google query URL, not shown in the input field
- On narrow viewports the expanded input may overlap the page title — this is intentional to avoid overrunning the right edge of the screen
- The small-screen `margin-top: -6px` workaround on `.btn-nav-search` and `.navbar-search-input` is documented in the CSS as a known alignment hack

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/Dpgkr7qzjh7C/implementations/97gmpGdF8mWL) | [App Preview](https://www.superconductor.com/tickets/Dpgkr7qzjh7C/implementations/97gmpGdF8mWL/preview) | [Guided Review](https://www.superconductor.com/tickets/Dpgkr7qzjh7C/implementations/97gmpGdF8mWL?tab=guided_review)

<!-- created-by-superconductor -->