### PR TITLE
Fix radio button behavior in self-check quizzes to allow deactivation

### DIFF
--- a/llab/script/quiz/multiplechoice.js
+++ b/llab/script/quiz/multiplechoice.js
@@ -161,7 +161,7 @@ MC.prototype.render = function() {
         <div class="option-row">
             <div class="${type}">
                 <label id="choicetext-${choice_id}" for="${choice_id}">
-                    <input type="${type}" id="${choice_id}" value="${this.removeSpace(optId)}" />
+                    <input type="${type}" name="q-${this.num}" id="${choice_id}" value="${this.removeSpace(optId)}" />
                     ${this.choices[i].text}
                 </label>
             </div>


### PR DESCRIPTION
## Fix radio button mutual exclusivity in self-check quizzes

Radio buttons in self-check quizzes could be activated but never deactivated — clicking a new option didn't clear the previously selected one, breaking standard single-selection behavior.

## Changes

- Added `name="q-${this.num}"` attribute to quiz `<input>` elements in `multiplechoice.js`, grouping radio buttons by question number
- This restores the browser's native mutual-exclusivity behavior for radio inputs, so selecting a new answer correctly deselects the previous one
- Checkboxes (used for multi-select questions) are unaffected by this change

## Root Cause

A prior refactor of the choice markup dropped the `name` attribute from the `<input>`. Without a shared `name`, the browser treats each radio button as its own independent group, so selections never clear each other. Adding `name="q-${this.num}"` scopes each radio group to its question, matching the existing `q-${this.num}-...` ID prefix convention.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/7FWmNLmqjWW7/implementations/pkjD7Kb7Dnqm) | [Guided Review](https://www.superconductor.com/tickets/7FWmNLmqjWW7/implementations/pkjD7Kb7Dnqm?tab=guided_review)

<!-- created-by-superconductor -->