### PR TITLE
Improve local ./run-server script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cur/programming/zot
 
 # Don't commit passwords publicly.
 .htpasswd
+
+# Self-signed certificates for the local dev server (./run-server --make-cert).
+utilities/certs/

--- a/README.md
+++ b/README.md
@@ -34,23 +34,61 @@ The main BJC repo can be viewed in a live state, [here](gh), or you can use your
 
 ## Running Your Own (Local) Server
 While GitHub pages are convenient, you'll likely want to run your own web server
-to make viewing changes much more quick and easy. In order to view the labs, you'll need to have an Apache server running on your machine. Here are some simple instructions for a couple different platforms.
+to make viewing changes much more quick and easy. Use `./run-server` — it is the
+supported way to develop locally, on every platform.
 
-__No matter the platform, you should server files from `/bjc-r/` at the root of your server.__
+```sh
+./run-server
+```
 
-### macOS and Unix
-The easiest way to setup a server is to use a simple, built-in Python server.
-1. `cd bjc-r` -- Ensure your current directory is at the root of `bjc-r/`
-2. Execute `./run-server`
-  2.1 This **must** be run from within bjc-r.
-  2.2 Press Control-C to end the server.
-3. Navigate to [http://localhost:8000/bjc-r][localhost] in a browser.
-4. That's it! :)
+That's it. It opens [http://localhost:8000/bjc-r][localhost] in your browser, and
+Control-C stops it. The only requirement is Python 3; on Windows, run it from
+PowerShell or WSL.
 
-This server requires Python 3.
+The server mirrors the URL layout of the real site, so absolute links like
+`/bjc-r/img/...` resolve exactly as they do in production.
 
-### Windows
-As long as you can install Python 3, you should be able to run the same script, either via PowerShell, or WSL, or some other means.
+Caching is disabled for the files you actually edit — `.html`, `.css`, `.js`,
+`.topic`, and `.xml`, the same set `.htaccess` marks no-cache in production — so
+a reload always shows the file you just saved and you should never need a hard
+refresh. Images and other assets cache normally, which keeps page loads fast.
+
+| Command | What it does |
+| --- | --- |
+| `./run-server` | Serve over http on port 8000 |
+| `./run-server 9000` | Use a different port |
+| `./run-server --https` | Serve over https (see below) |
+| `./run-server --no-open` | Don't open a browser window |
+| `./run-server --make-cert` | Replace the https certificate |
+| `./run-server --help` | List every option |
+
+If the port is already in use, the server says so and tells you how to find what
+is holding it (`lsof -i tcp:8000`).
+
+### Serving over https
+
+A few things — service workers, some clipboard and media APIs — only work on a
+secure origin. `./run-server --https` covers those cases:
+
+```sh
+./run-server --https
+```
+
+The first run generates a self-signed certificate for `localhost` in
+`utilities/certs/` (gitignored). It is good for 30 days and is regenerated
+automatically once it is within a week of expiring, so it can never silently go
+stale. To replace it at any time, run `./run-server --make-cert`.
+
+Because the certificate signs itself, your browser will warn you the first time.
+Click through it, or teach macOS to trust it once:
+
+```sh
+security add-trusted-cert -r trustRoot -k ~/Library/Keychains/login.keychain-db utilities/certs/localhost.pem
+```
+
+(You'll need to re-run that after each regeneration. If you'd rather not, a tool
+like [mkcert](https://github.com/FiloSottile/mkcert) can install a local CA once
+and issue certificates your browser trusts without a prompt.)
 
 ## Contributing
 

--- a/utilities/dev_cert.py
+++ b/utilities/dev_cert.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Self-signed certificate for the local dev server (see server.py).
+
+Certificates are deliberately short-lived throwaway credentials for localhost,
+regenerated automatically as they near expiry.
+"""
+
+import ssl
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CERT_DIR = REPO_ROOT / "utilities" / "certs"
+CERT_FILE = CERT_DIR / "localhost.pem"
+KEY_FILE = CERT_DIR / "localhost-key.pem"
+
+DAYS = 30
+RENEW_WITHIN_DAYS = 7
+
+# A config file rather than `-addext` flags, which the LibreSSL that macOS ships
+# as /usr/bin/openssl doesn't support.
+OPENSSL_CONFIG = """
+[req]
+distinguished_name = dn
+x509_extensions = ext
+prompt = no
+
+[dn]
+CN = localhost
+O = BJC local development
+
+[ext]
+subjectAltName = DNS:localhost, IP:127.0.0.1, IP:::1
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+"""
+
+TRUST_HINT = f"""\
+Your browser will warn that the certificate is untrusted. Click through it, or
+on macOS trust it once:
+  security add-trusted-cert -r trustRoot \\
+      -k ~/Library/Keychains/login.keychain-db {CERT_FILE}"""
+
+
+def is_fresh():
+    """True if a certificate exists and isn't about to expire."""
+    if not (CERT_FILE.exists() and KEY_FILE.exists()):
+        return False
+    checkend = subprocess.run(
+        ["openssl", "x509", "-checkend", str(RENEW_WITHIN_DAYS * 86400),
+         "-noout", "-in", str(CERT_FILE)],
+        capture_output=True,
+    )
+    return checkend.returncode == 0
+
+
+def generate():
+    """Write a new short-lived certificate and key, replacing any existing pair."""
+    try:
+        subprocess.run(["openssl", "version"], capture_output=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        sys.exit("openssl is required to generate a certificate, but was not found.")
+
+    CERT_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", suffix=".cnf") as config:
+        config.write(OPENSSL_CONFIG)
+        config.flush()
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-sha256",
+             "-days", str(DAYS), "-nodes",
+             "-keyout", str(KEY_FILE), "-out", str(CERT_FILE),
+             "-config", config.name],
+            check=True, capture_output=True,
+        )
+    KEY_FILE.chmod(0o600)
+
+    print(f"Wrote a {DAYS}-day certificate for localhost:")
+    print(f"  {CERT_FILE}")
+    print(f"  {KEY_FILE}")
+    print(f"\n{TRUST_HINT}")
+
+
+def ssl_context():
+    """An SSL context for localhost, generating the certificate if needed."""
+    if not is_fresh():
+        print(f"Certificate is {'expiring soon' if CERT_FILE.exists() else 'missing'};"
+              " generating a new one.\n")
+        generate()
+        print()
+
+    # create_default_context picks sensible protocol and cipher settings for us.
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(CERT_FILE, KEY_FILE)
+    context.set_alpn_protocols(["http/1.1"])
+    return context

--- a/utilities/server.py
+++ b/utilities/server.py
@@ -1,47 +1,186 @@
 #!/usr/bin/env python3
-from http.server import HTTPServer, SimpleHTTPRequestHandler, test
-import sys, ssl, socketserver, subprocess, time
+"""Local development server for the BJC curriculum.
 
-PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
-DIRECTORY = "../"
+Serves this repository at http://localhost:8000/bjc-r/, matching the URLs used
+in production, so absolute links like `/bjc-r/img/...` resolve correctly.
 
-class BJCServer(SimpleHTTPRequestHandler):
+    ./run-server                 # http on port 8000, opens a browser
+    ./run-server 9000            # http on port 9000
+    ./run-server --https         # https, generating a cert if needed
+    ./run-server --make-cert     # regenerate the self-signed cert and exit
+    ./run-server --no-open       # don't open a browser
+"""
+
+import argparse
+import contextlib
+import errno
+import ssl
+import sys
+import webbrowser
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import dev_cert
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Content links are absolute and rooted at /bjc-r/, so requests arrive with that
+# prefix even though the checkout itself is the document root.
+URL_PREFIX = "/bjc-r"
+
+DEFAULT_PORT = 8000
+
+# The files an author edits directly, matching the no-cache `filesMatch` rule in
+# .htaccess. Everything else caches normally.
+UNCACHED_SUFFIXES = (".html", ".htm", ".css", ".js", ".topic", ".xml")
+
+CONNECTION_TIMEOUT = 30
+
+
+class BJCRequestHandler(SimpleHTTPRequestHandler):
+    """Serves the checkout under /bjc-r/, CORS-open, authored files uncached."""
+
+    # Keep-alive. Under the HTTP/1.0 default every asset needed a fresh
+    # connection, which over TLS meant a fresh handshake per file.
+    protocol_version = "HTTP/1.1"
+
+    timeout = CONNECTION_TIMEOUT
+
+    # Headers and body are written separately; without this, Nagle holds the
+    # second write for a ~40ms delayed ACK on every file.
+    disable_nagle_algorithm = True
+
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, directory=DIRECTORY, **kwargs)
+        super().__init__(*args, directory=str(REPO_ROOT), **kwargs)
 
-    def end_headers (self):
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Credentials', 'true')
-        self.send_header('Vary', 'Origin')
-        SimpleHTTPRequestHandler.end_headers(self)
+    def translate_path(self, path):
+        if path == URL_PREFIX:
+            path = "/"
+        elif path.startswith(URL_PREFIX + "/") or path.startswith(URL_PREFIX + "?"):
+            path = path[len(URL_PREFIX):]
+        return super().translate_path(path)
 
-def https_server():
-    # TODO: This is currently very slow to serve files.
-    # Generate cert.pem with the following command:
-    # openssl req -new -x509 -keyout cert.pem -out cert.pem -days 365 -nodes
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    context.load_cert_chain("utilities/cert.pem")
-    server_address = ("localhost", PORT)
-    handler = BJCServer
-    with socketserver.TCPServer(server_address, handler) as httpd:
-        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
-        httpd.serve_forever()
+    def is_authored_file(self):
+        # `path` is unset when the request line itself was malformed.
+        path = getattr(self, "path", "").split("?", 1)[0].split("#", 1)[0]
+        # A directory URL serves the index.html inside it.
+        return path.endswith("/") or path.lower().endswith(UNCACHED_SUFFIXES)
 
-def serve_from_port():
-    global PORT
+    def send_head(self):
+        if self.path == "/":
+            self.send_response(302)
+            self.send_header("Location", URL_PREFIX + "/")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return None
+
+        if self.is_authored_file():
+            # A reload must show the file you just saved, so never answer with
+            # "304 Not Modified".
+            del self.headers["If-Modified-Since"]
+            del self.headers["If-None-Match"]
+        return super().send_head()
+
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Credentials", "true")
+        self.send_header("Vary", "Origin")
+        if self.is_authored_file():
+            self.send_header("Cache-Control",
+                             "no-store, no-cache, must-revalidate, max-age=0")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
+        super().end_headers()
+
+
+class DevHTTPServer(ThreadingHTTPServer):
+    """Threaded, so one slow or abandoned connection can't stall the others."""
+
+    def handle_error(self, request, client_address):
+        # Browsers open speculative connections and abandon them, and cancel
+        # image loads mid-download. Neither is worth a traceback.
+        if isinstance(sys.exc_info()[1], (ssl.SSLError, ConnectionError, TimeoutError)):
+            return
+        super().handle_error(request, client_address)
+
+
+class DevHTTPSServer(DevHTTPServer):
+    """Adds TLS, keeping the handshake off the accept loop.
+
+    Wrapping the listening socket (what http.server's own HTTPSServer does)
+    runs every handshake inside the single accept loop, so one browser opening
+    a connection it never uses blocks every other request.
+    """
+
+    def __init__(self, server_address, handler_class, ssl_context):
+        self.ssl_context = ssl_context
+        super().__init__(server_address, handler_class)
+
+    def get_request(self):
+        connection, address = super().get_request()
+        return self.ssl_context.wrap_socket(
+            connection, server_side=True, do_handshake_on_connect=False
+        ), address
+
+    def finish_request(self, request, client_address):
+        # Runs on a worker thread, so a slow handshake only affects its own
+        # connection.
+        request.settimeout(CONNECTION_TIMEOUT)
+        request.do_handshake()
+        super().finish_request(request, client_address)
+
+
+def start_server(port, context):
+    address = ("localhost", port)
     try:
-        test(BJCServer, HTTPServer, port=PORT)
-    except:
-        PORT += 10
-        print(f"Port {PORT-10} seems blocked, using port {PORT}")
-        test(BJCServer, HTTPServer, port=PORT)
+        if context:
+            return DevHTTPSServer(address, BJCRequestHandler, context)
+        return DevHTTPServer(address, BJCRequestHandler)
+    except OSError as error:
+        if error.errno != errno.EADDRINUSE:
+            raise
+        # Here is how to find what is running on port 8000.
+        sys.exit(f"Port {port} is already in use. To see what has it:\n"
+                 f"  lsof -i tcp:{port}\n"
+                 f"Then stop it, or pick another port: ./run-server {port + 1}")
 
-def open_on_mac():
-    has_open = subprocess.run(['which', 'open'])
-    if has_open.returncode == 0:
-        subprocess.run(['open', f'http://localhost:{PORT}/bjc-r/'])
 
-if __name__ == '__main__':
-    # serve_from_port()
-    open_on_mac()
-    test(BJCServer, HTTPServer, port=PORT)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("port", nargs="?", type=int, default=DEFAULT_PORT,
+                        help=f"port to listen on (default: {DEFAULT_PORT})")
+    parser.add_argument("--https", action="store_true",
+                        help="serve over TLS using a self-signed certificate")
+    parser.add_argument("--make-cert", action="store_true",
+                        help="regenerate the self-signed certificate and exit")
+    parser.add_argument("--no-open", action="store_true",
+                        help="do not open a browser window")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.make_cert:
+        dev_cert.generate()
+        return
+
+    context = dev_cert.ssl_context() if args.https else None
+    server = start_server(args.port, context)
+    url = f"{'https' if args.https else 'http'}://localhost:{args.port}{URL_PREFIX}/"
+
+    print(f"Serving {REPO_ROOT} at {url}")
+    print("Press Control-C to stop.")
+
+    if not args.no_open:
+        webbrowser.open(url)
+
+    with server:
+        with contextlib.suppress(KeyboardInterrupt):
+            server.serve_forever()
+        print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Standardize local dev environment with `./run-server` and improve HTTPS support

Establishes `./run-server` as the single supported local development path, fixes significant HTTPS performance issues, adds self-signed certificate management, and scopes cache-busting to authored files only.

## Changes

**HTTPS performance fixes (`utilities/server.py`)**
- Switched to `ThreadingHTTPServer` with HTTP/1.1 keep-alive, eliminating a new TLS handshake per file (old: 54 connections for 48 assets; new: 6)
- Deferred TLS handshake to worker threads via `get_request`/`finish_request` override — the old approach wrapped the listening socket, causing one stalled connection to freeze the entire server for ~15s
- Added `TCP_NODELAY` (`disable_nagle_algorithm`) to prevent ~40ms delayed-ACK penalty per file on kept-alive TLS connections

**Self-signed certificate management (`utilities/dev_cert.py`)**
- New `--https` flag to serve over TLS; `--make-cert` to regenerate the certificate
- Certificates are 30-day, localhost-scoped, with SANs; auto-regenerated within 7 days of expiry
- Uses an OpenSSL config file for SAN support (macOS's LibreSSL doesn't support `-addext`)
- `utilities/certs/` is gitignored

**Scoped cache-busting**
- `no-store` headers applied only to authored files (`.html`, `.css`, `.js`, `.topic`, `.xml`) — matching the production `.htaccess` ruleset
- Images and other assets cache normally, keeping page loads fast while ensuring edits are always visible on reload without a hard refresh

**CLI improvements**
- Removed port auto-stepping; on conflict, exits with a clear message including `lsof -i tcp:8000` hint
- Added `--no-open` and `--help` flags
- Server now works from any directory (not just inside `bjc-r/`)

**README**
- Rewritten server section around `./run-server` as the primary path
- Removed platform-specific Apache instructions and the old macOS/Windows split
- Documents HTTPS setup, certificate trust, and all CLI flags

## Screenshots

[HTTPS dev server serving a real lab page (90 responses, all assets resolving)](https://www.superconductor.com/ticket_implementations/f6qbJFkbcdBm/artifacts/FPhNfkjWFBnQ)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/HJmTBcQRzdTh/implementations/f6qbJFkbcdBm) | [App Preview](https://www.superconductor.com/tickets/HJmTBcQRzdTh/implementations/f6qbJFkbcdBm/preview) | [Guided Review](https://www.superconductor.com/tickets/HJmTBcQRzdTh/implementations/f6qbJFkbcdBm?tab=guided_review)

<!-- created-by-superconductor -->