### PR TITLE
Implement anchor navigation for vocab, self-checks, and exam content

### DIFF
--- a/cur/programming/1-introduction/unit-1-exam-reference.es.html
+++ b/cur/programming/1-introduction/unit-1-exam-reference.es.html
@@ -11,14 +11,14 @@
 </head>
 <body>
 <h2>Laboratorio 2: Conversaciones</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box1"><strong>laboratorio 2, página 2</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 2, página 2</strong></a>
             <div class="ap-standard">AAP-3.A.6</div>
             <div class="pseudop">
                 En el examen AP no hay un bloque exactamente igual a <img class="nopadtb" src="/bjc-r/img/1-introduction/say-gossip.es.png" alt="decir (chisme)" title="decir (chisme)"> o <img class="nopadtb" src="/bjc-r/img/1-introduction/say-gossip-for-3-secs.es.png" alt="decir (chisme) por (3) segundos" title="decir (chisme) por (3) segundos"> ya que no tienen personajes o globos de conversación. En su lugar, la forma correcta de presentar texto al usuario es utilizar, en inglés,
                 <pre class="inline">DISPLAY(chisme())</pre>, en el caso que esté escrito como texto, o de la forma <img class="nopadtb" src="/bjc-r/img/1-introduction/display(gossip).es.png" alt="un rectángulo blanco con dos palabras, la primera es 'DISPLAY' en mayúsculas y la segunda 'gossip' en minúsculas" title="un rectángulo blanco con dos palabras, la primera es 'DISPLAY' en mayúsculas y la segunda 'gossip' en minúsculas"> si está representado como un bloque.
             </div>
             <p>No sería necesario que sepas <em>escribir</em> código utilizando esta notación en el examen AP. Solo debes ser capaz de <em>leerlo</em> para que puedas responder a las preguntas relacionadas con dicha funcionalidad.</p>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box3"><strong>laboratorio 2, página 4</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 2, página 4</strong></a>
             <div class="ap-standard">AAP-3.A.7, AAP-3.C.2</div>
             <ul>   
                 <li>
@@ -44,12 +44,12 @@
                     <div class="ap-standard">AAP-3.A.9</div>
                 </li>
             </ul>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box8"><strong>laboratorio 2, página 5</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 2, página 5</strong></a>
             <div class="ap-standard">AAP-3.E.1</div>
             <div class="ap-standard">AAP-3.E.2</div>
             <div class="pseudop">La expresión <img class="inline" src="/bjc-r/img/blocks/pick-random-1-to-10-full-size.es.png" alt="número al azar entre (1) y (10)" title="número al azar entre (1) y (10)"> será presentada con la notación en inglés <pre class="inline">RANDOM(1, 10)</pre> or <img class="inline" src="/bjc-r/img/1-introduction/random-blocktran.png" alt="RANDOM(1, 10)" title="RANDOM(1, 10)">. Cada vez que se ejecuta este código, vas a obtener un número aleatorio entre 1 y 10.</div>
         </div><h2>Laboratorio 3: Arte moderno con polígonos</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box13"><strong>laboratorio 3, página 4</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 3, página 4</strong></a>
 			<div class="ap-standard">AAP-3.C.1, AAP-2.K.2</div>
 			<div class="pseudop">
                 La definición del comando personalizado <code>molinete</code> que se muestra a continuación <br>
@@ -102,12 +102,12 @@ PROCEDURE molinete(numeroDeRamas)
                 <div class="pseudop">Los procedimientos <pre class="inline">mover()</pre> y <pre class="inline">girar_sentidodelreloj()</pre> no forman parte del lenguaje AP, por lo que están escrito en minúsculas, de la misma forma que otros procedimientos definidos por el programador.</div>
             <div class="pseudop">Ten en cuenta que el bloque sombrero, <img class="inline nopadtb" src="/bjc-r/img/1-introduction/pinwheel-hat-block.es.png" alt="molinete, ramas: (número de ramas)" title="molinete, ramas: (número de ramas)">, se escribiría como <pre class="inline">PROCEDURE molinete(numeroDeRamas)</pre>. La palabra <pre class="inline">procedure</pre> (procedimiento) te indica que la línea de código es como un bloque sombrero; el nombre de la variable entre paréntesis en esa línea es la entrada que toma el procedimiento.</div>
             </div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box14"><strong>laboratorio 3, página 4</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-2"><strong>laboratorio 3, página 4</strong></a>
             <div class="ap-standard">AAP-3.A.5</div>
             <div class="pseudop">La siguiente instrucción <img class="inline" src="/bjc-r/img/1-introduction/U1ImageVideoAddendum_img/U1L3-PinwheelwithInputs1.es.png" alt="molinete, ramas: (6) tamaño: (80) respaldo: (20)" title=" molinete, ramas: (6) tamaño: (80) respaldo: (20)"> tendría la siguiente notación <pre class="inline">molinete(6, 80, 20)</pre> o <img class="nopadtb" src="/bjc-r/img/1-introduction/pinwheel-blocktran.es.png" alt="un rectángulo blanco que contiene la palabra 'molinete' en mayúsculas seguida de un rectángulo más pequeño que contiene las entradas'6, 80, 20'" title="un rectángulo blanco que contiene la palabra 'molinete' en mayúsculas seguida de un rectángulo más pequeño que contiene las entradas'6, 80, 20'">.</div>
             <p>Posiblemente has escuchado que algunas personas utilizan el término "pseudocódigo" para referirse a este pseudo-lenguaje usado en el examen de principios AP CS, pero esto <em>no</em> es pseudocódigo. El pseudocódigo no es un lenguaje de programación, se usa cómo un lenguaje humano natural para describir un algoritmo.</p>
         </div><h2>Laboratorio 5: Seguir un objeto</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box25"><strong>laboratorio 5, página 2</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 5, página 2</strong></a>
             <div class="ap-standard">AAP-2.K.3</div>
             <div class="sidenoteBig">
                 <div class="pseudop">El lenguaje utilizado en el examen AP no permite espacios en los nombres de las entradas (como <var>número de peces</var>) o en los procedimientos definidos por el programador (como <code>ratón y</code>, que no está integrado en su idioma). Así que este ejemplo los traduce a <pre class="inline">numPeces</pre> y <pre class="inline">ratónY()</pre>.</div>

--- a/cur/programming/1-introduction/unit-1-exam-reference.html
+++ b/cur/programming/1-introduction/unit-1-exam-reference.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Lab 2: Gossip</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box1"><strong>Lab 2, Page 2</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-1"><strong>Lab 2, Page 2</strong></a>
 			<!--<div class="index-term anchor" id="say</code>">&nbsp;</div>-->
 			<div class="ap-standard">AAP-3.A.6</div>
             <div class="pseudop">
@@ -23,7 +23,7 @@
                 <pre class="inline">DISPLAY(gossip())</pre> if it's written as text or <img class="nopadtb" src="/bjc-r/img/1-introduction/display(gossip).png" alt="a white rounded rectangle containing first the word 'DISPLAY' in all caps and then a smaller white rectangle containing the word 'gossip' in lower case" title="a white rounded rectangle containing first the word 'DISPLAY' in all caps and then a smaller white rectangle containing the word 'gossip' in lower case"> if it's shown as blocks.
             </div>
             <p>You won't have to be able to <em>write</em> code in this notation on the AP exam. You just have to be able to <em>read</em> it so you can answer questions about it.</p>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box3"><strong>Lab 2, Page 4</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-1"><strong>Lab 2, Page 4</strong></a>
             <div class="python">
 				<a href="#hint-python-1-2-4-1" data-bs-toggle="collapse" title="What would this look like in Python?">What would this look like in Python?</a>
 				<div id="hint-python-1-2-4-1" class="collapse">
@@ -58,7 +58,7 @@ def double(number):
                     <div class="ap-standard">AAP-3.A.9</div>
                 </li>
             </ul>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box8"><strong>Lab 2, Page 5</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-1"><strong>Lab 2, Page 5</strong></a>
 			<!--<div class="index-term" id="pick random</code>"></div>-->
             <div class="ap-standard">AAP-3.E.1, AAP-3.E.2</div>
             <div class="pseudop">The expression <img class="inline" src="/bjc-r/img/blocks/pick-random-1-to-10-full-size.png" alt="pick random (1) to (10)" title="pick random (1) to (10)"> would be written as <pre class="inline">RANDOM(1, 10)</pre> or <img class="inline" src="/bjc-r/img/1-introduction/random-blocktran.png" alt="RANDOM(1, 10)" title="RANDOM(1, 10)">. Every time you run this code, you will get a different random number between 1 and 10.</div>
@@ -72,7 +72,7 @@ randint(1, 10)</code></pre>
 				</div>
 			</div>
         </div><h2>Lab 3: Modern Art with Polygons</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box13"><strong>Lab 3, Page 4</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-1"><strong>Lab 3, Page 4</strong></a>
             <div class="ap-standard">AAP-3.C.1, AAP-2.K.2</div>
             <div class="pseudop">
 				<div class="python">
@@ -144,7 +144,7 @@ PROCEDURE pinwheel(numberOfBranches)
 				</div>
                 <div class="pseudop">Notice that the hat block, <img class="inline nopadtb" src="/bjc-r/img/1-introduction/pinwheel-hat-block.png" alt="pinwheel, branches: (number of branches)" title="pinwheel, branches: (number of branches)">, would be written as <pre class="inline">PROCEDURE pinwheel(numberOfBranches)</pre>. The word <pre class="inline">PROCEDURE</pre> tells you that that line of the code is like a hat block; the variable name in the parentheses on that line is the input that the procedure takes.</div>
             </div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box14"><strong>Lab 3, Page 4</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-2"><strong>Lab 3, Page 4</strong></a>
 			<div class="python">
 				<a href="#hint-python-1-3-4-4" data-bs-toggle="collapse" title="What would this look like in Python?">What would this look like in Python?</a>
 				<div id="hint-python-1-3-4-4" class="collapse">
@@ -155,7 +155,7 @@ PROCEDURE pinwheel(numberOfBranches)
             <div class="pseudop">This instruction <img class="inline" src="/bjc-r/img/1-introduction/U1ImageVideoAddendum_img/U1L3-PinwheelwithInputs1.png" height="50" alt="setup; pinwheel, branches: (6) size: (80) backup: (20)" title=" pinwheel, branches: (6) size: (80) backup: (20)"> would be written as <pre class="inline">Pinwheel(6, 80, 20)</pre> or <img class="nopadtb" src="/bjc-r/img/1-introduction/pinwheel-blocktran.png" alt="a white rounded rectangle containing first the word 'PINWHEEL' in all caps and then a smaller white rectangle containing the inputs '6, 80, 20'" title="a white rounded rectangle containing first the word 'PINWHEEL' in all caps and then a smaller white rectangle containing the inputs '6, 80, 20'">.</div>
             <p>You may hear people use the term "pseudocode" to refer to this pseudo-language used on the AP CS Principles exam, but it's <em>not</em> pseudocode. Pseudocode isn't a programming language at all, it's the use of normal human language to describe an algorithm.</p>
         </div><h2>Lab 5: Follow the Leader</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box24"><strong>Lab 5, Page 2</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#exam-1"><strong>Lab 5, Page 2</strong></a>
             <div class="ap-standard">AAP-2.K.3</div>
             <div class="sidenoteBig">
                 <div class="pseudop">The language used on the AP Exam doesn't allow spaces in names of inputs (such as <var>number of fish</var>) or in programmer-defined procedures (such as <code>mouse y</code>, which isn't built into their language). So this example translates them to <pre class="inline">numFish</pre> and <pre class="inline">MouseY()</pre>.</div>

--- a/cur/programming/1-introduction/unit-1-self-check.es.html
+++ b/cur/programming/1-introduction/unit-1-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 2: Conversaciones</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Cuál o cuáles de las siguientes cadenas representa un posible resultado de ejecutar el código &lt;code&gt;chisme&lt;/code&gt;?" hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_1_2_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box2"><strong>laboratorio 2, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 3</strong></a>
 </div>
 
 						<div class="prompt">
@@ -56,7 +56,7 @@
 						</div>
 					</div><div class="assessment-data" type="multiplechoice" identifier="About how often will más complicado quién pick the more complicated choice?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_2_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box4"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -105,7 +105,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="About how often will más complicado quién pick the more complicated choice?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_2_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box5"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -153,7 +153,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Qué expresión va a devolver un número aleatorio &lt;em&gt;par&lt;/em&gt; entre 1 y 10?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_1_2_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box6"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -196,7 +196,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Cuál de las siguientes expresiones simula el resultado de lanzar dos dados?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_1_2_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box7"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-4"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -235,7 +235,7 @@
                     </div><h2>Laboratorio 3: Arte moderno con polígonos</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which of the following are examples of algorithms?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_1" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box9"><strong>laboratorio 3, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -277,7 +277,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What shape would the following script draw?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/2-exploring-snap-drawing-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box10"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/2-exploring-snap-drawing-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -313,7 +313,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Compare and contrast the two scripts shown here." hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_1_3_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box11"><strong>laboratorio 3, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -352,7 +352,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What correctly describes the choice of whether or not to use a procedure to draw the pinwheels?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box12"><strong>laboratorio 3, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -389,7 +389,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which statement best illustrates the importance of using parameters in programming procedures?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/5-remix-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box15"><strong>laboratorio 3, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/5-remix-your-pinwheel.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -425,7 +425,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Given the program code below, what will the output be?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box16"><strong>laboratorio 3, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -463,7 +463,7 @@
                     </div><h2>Laboratorio 4: Proteger tu privacidad</h2>
 <div class="assessment-data" type="multiplechoice" identifier="¿Cuál es un efecto potencial de tener tu PII (información de identificación personal) compartida en línea?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box17"><strong>laboratorio 4, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -499,7 +499,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Al vender datos a terceros sin el consentimiento del consumidor, ¿qué está haciendo una empresa de lo siguiente?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box18"><strong>laboratorio 4, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -535,7 +535,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Cuál de los siguientes es un ejemplo de cómo la PII y otra información recopilada por un sitio web pueden ser utilizadas para beneficiar al usuario?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_4_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box19"><strong>laboratorio 4, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 4, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -576,7 +576,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Por qué hubo un retraso en el uso de registros de teléfonos celulares para localizar a la persona perdida, Tanya Rider?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/3-tanya-rider.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box20"><strong>laboratorio 4, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/3-tanya-rider.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -611,7 +611,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Cuál es la razón principal por la que la tecnología de reconocimiento facial se considera controvertida?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box21"><strong>laboratorio 4, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -647,7 +647,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Qué tipo de datos pueden recopilar los sitios web sobre sus visitantes sin su conocimiento?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_4_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box22"><strong>laboratorio 4, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 4, página 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -684,7 +684,7 @@
                     </div><h2>Laboratorio 5: Seguir un objeto</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Cuando se ejecuta el código de abajo, ¿cuál describe correctamente cuántas veces el sprite se mueve 10 pasos y por qué?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_5_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box23"><strong>laboratorio 5, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 5, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -721,7 +721,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Cuando se ejecuta el código a continuación, ¿cuántas veces se mueve el sprite 10 pasos?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_5_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#box24"><strong>laboratorio 5, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 5, página 2</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/1-introduction/unit-1-self-check.html
+++ b/cur/programming/1-introduction/unit-1-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 2: Gossip</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which of the following sentences could be reported by gossip?" hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_1_2_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box2"><strong>Lab 2, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 3</strong></a>
 </div>
 
 						<div class="prompt">
@@ -56,7 +56,7 @@
 						</div>
 					</div><div class="assessment-data" type="multiplechoice" identifier="About how often will more complicated who pick the more complicated choice?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_2_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box4"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -105,7 +105,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="About how often will more complicated who pick the more complicated choice?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_2_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box5"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -154,7 +154,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What expression would return a random even number between 1 and 10?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_1_2_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box6"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -197,7 +197,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which expression will simulate the rolling of two dice?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_1_2_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box7"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-4"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -236,7 +236,7 @@
                     </div><h2>Lab 3: Modern Art with Polygons</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which of the following are examples of algorithms?" hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_1_3_1" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box9"><strong>Lab 3, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -281,7 +281,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What shape would the following script draw?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/2-exploring-snap-drawing-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box10"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/2-exploring-snap-drawing-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -317,7 +317,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Compare and contrast the two scripts shown here." hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_1_3_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box11"><strong>Lab 3, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -356,7 +356,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What correctly describes the choice of whether or not to use a procedure to draw the pinwheels?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box12"><strong>Lab 3, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -393,7 +393,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which statement best illustrates the importance of using parameters in programming procedures?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/5-remix-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box15"><strong>Lab 3, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/5-remix-your-pinwheel.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -429,7 +429,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Given the program code below, what will the output be?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_3_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box16"><strong>Lab 3, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -467,7 +467,7 @@
                     </div><h2>Lab 4: Protecting Your Privacy</h2>
 <div class="assessment-data" type="multiplechoice" identifier="What is a potential effect of having your PII shared online?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box17"><strong>Lab 4, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -503,7 +503,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="By selling data to third parties without the consumer's consent, a company is doing which of the following?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box18"><strong>Lab 4, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -539,7 +539,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which of the following is an example of how PII and other information collected by a website can be used to benefit the user?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_4_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box19"><strong>Lab 4, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/2-examining-privacy.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 4, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -580,7 +580,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the primary reason why facial recognition technology is considered controversial?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_4_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box20"><strong>Lab 4, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -616,7 +616,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What type of data can websites collect about their visitors without their knowledge?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_4_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box21"><strong>Lab 4, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/4-privacy/4-privacy-affected.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 4, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -653,7 +653,7 @@
                     </div><h2>Lab 5: Follow the Leader</h2>
 <div class="assessment-data" type="multiplechoice" identifier="When the code below is executed, how many times will the sprite move 10 steps?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_1_5_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box22"><strong>Lab 5, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 5, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -690,7 +690,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="When the code below is executed, how many times does the sprite move 10 steps?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_1_5_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#box23"><strong>Lab 5, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 5, Page 2</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/1-introduction/unit-1-vocab.es.html
+++ b/cur/programming/1-introduction/unit-1-vocab.es.html
@@ -13,7 +13,7 @@
 <h2>Unidad 1: Introducción a la programación</h2>
 <h3>Laboratorio 1: El juego de hacer clic en Alonzo</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box0"><b>Laboratorio 1, página 4</b></a>: <strong>Objetos</strong> y <strong>disfraces</strong>
+<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 4</b></a>: <strong>Objetos</strong> y <strong>disfraces</strong>
 			<p>El personaje de Alonzo lleva el nombre de Alonzo Church, uno de los principales contribuyentes a las primeras ciencias de la computación. En este proyecto, hay tres objetos relacionados con Alonzo:
 				</p>
 <ul>
@@ -23,7 +23,7 @@
 			
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box1"><b>Laboratorio 1, página 4</b></a>: <strong>Transparencia</strong>
+<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 4</b></a>: <strong>Transparencia</strong>
             <p>
                 La <strong>transparencia</strong> (<em>transparency</em>) de una imagen es cuánto puedes ver lo que hay detrás de ella. Por ejemplo, aquí se muestra el objeto de Alonzo con tres transparencias diferentes (que se han configurado usando el bloque de <code>efecto fantasma</code> ).<br>
                 <img class="indent" src="/bjc-r/img/1-introduction/transparency2.es.png" title="tres imágenes de Alonzo, con efecto fantasma de 0%, 25% y 50%, sobre una pared de ladrillo" alt="tres imágenes de Alonzo, con efecto fantasma de 0%, 25% y 50%, sobre una pared de ladrillo">
@@ -31,7 +31,7 @@
         </div>
 <h3>Laboratorio 2: Conversaciones</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box2"><b>Laboratorio 2, página 3</b></a>: <strong>Listas</strong>, <strong>cadenas</strong> y <strong>concatenación</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 3</b></a>: <strong>Listas</strong>, <strong>cadenas</strong> y <strong>concatenación</strong>
 			<ul>
 				<li>
                     <div class="ap-standard">AAP-1.C.1 first sentence</div>
@@ -56,11 +56,11 @@
 			</ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box3"><b>Laboratorio 2, página 3</b></a>: <strong>Depuración</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 3</b></a>: <strong>Depuración</strong>
 					<p>El proceso de probar, buscar problemas y arreglarlos se llama <strong>depuración</strong> (<em>debugging</em>). Utilizaremos también el término en inglés, <em>debugging</em>, que viene de la palabra "bug" o "error" y representa la acción de buscar errores en nuestro programa.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box4"><b>Laboratorio 2, página 4</b></a>: <strong>Procedimientos</strong>, <strong>reporteros</strong> y <strong>comandos</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 4</b></a>: <strong>Procedimientos</strong>, <strong>reporteros</strong> y <strong>comandos</strong>
             <div class="ap-standard">AAP-3.A.1, AAP-3.A.2</div>
             <p>
                 Un <strong>procedimiento</strong> (<em>procedure</em>) es una secuencia de instrucciones que puede aceptar valores o acciones de entrada y puede reportar un valor como resultado. Los procedimientos pueden recibir un nombre para distinguirlos. Algunos lenguajes de programación los pueden llamar también <em>métodos</em> o <em>funciones</em>. A continuación se presentan dos tipos de procedimientos que ya has visto en Snap<em>!</em>:
@@ -82,7 +82,7 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box5"><b>Laboratorio 2, página 5</b></a>: <strong>Expresiones</strong> y <strong>valores</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 5</b></a>: <strong>Expresiones</strong> y <strong>valores</strong>
             <div class="ap-standard">AAP-2.B.3, AAP-2.B.4</div>
             <ul>
                 <li>Una <strong>expresión</strong> (<em>expression</em>) es un valor constante (por ejemplo "4" o "invierno") o bien una llamada a un bloque reportero con cualquier campo de entrada con datos ingresados (por ejemplo: <img class="" src="/bjc-r/img/2-complexity/number.es.png" alt="número" title="número">, <img class="inline nopadtb" src="/bjc-r/img/1-introduction/5+(4x3).png" alt="5 + (4 * 3)" title="5 + (4 * 3)">, o <img class="" src="/bjc-r/img/2-complexity/join-who-doeswhat-who.es.png" alt="unir (quién) ( ) (hace) ( ) (quién)" title="unir (quién) ( ) (hace) ( ) (quién)">).</li>
@@ -91,13 +91,13 @@
         </div>
 <h3>Laboratorio 3: Arte moderno con polígonos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box6"><b>Laboratorio 3, página 1</b></a><strong>: Algoritmos</strong> y <strong>pseudocódigo</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 1</b></a><strong>: Algoritmos</strong> y <strong>pseudocódigo</strong>
             <div class="ap-standard">AAP-2.A.1, AAP-2.A.2, AAP-2.A.3</div>
             <p>Un <strong>algoritmo</strong> (<em>algorithm</em>) es una secuencia de pasos que usualmente ejecuta una computadora. El algoritmo no requiere estar escrito en un lenguaje de programación en particular, ni siquiera en un lenguaje de programación. Puede ser escrito en nuestro lenguaje natural en la forma de una secuencia de oraciones que realiza una serie de actividades. Se conoce a un algoritmo escrito en lenguaje natural como <strong>pseudocódigo</strong> (<em>pseudocode</em>). Una vez que se tiene la idea clara de los pasos a ejecutar, el algoritmo puede escribirse en el lenguaje de programación de tu elección.</p>
             <div class="endnote">¿Cuál es el propósito del "pseudocódigo"?  "Pseudo" significa, literalmente, "falso o irreal"; ¿Por qué escribir un algoritmo en nuestro lenguaje natural en lugar de uno tan preciso como Snap<i>!</i>? Si fueras a programar utilizando un lenguaje cargado de puntuación, diseñar tu programa en pseudocódigo te ayudaría a enfocarte en las ideas más importantes en lugar de los detalles como los signos de puntuación o un punto y coma. Sin embargo, el pseudocódigo no es tan necesario en un lenguaje como Snap<em>!</em>. Además, el pseudocódigo puede hacer que te hagas ilusiones acerca de lo que es capaz de hacer una computadora (como por ejemplo, "Selecciona los números ganadores para la lotería de mañana; anótalos y compra el billete de lotería" o "Aquí está la melodía; escribe la armonía").</div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box7"><b>Laboratorio 3, página 3</b></a>: ¿Qué es una entrada? <strong>Parámetro</strong> vs. <strong>Argumento</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 3</b></a>: ¿Qué es una entrada? <strong>Parámetro</strong> vs. <strong>Argumento</strong>
             <div class="ap-standard">AAP-3.A.3</div>
             <p>
                 </p>
@@ -115,7 +115,7 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box8"><b>Laboratorio 3, página 6</b></a>: <strong>Iteración</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 6</b></a>: <strong>Iteración</strong>
             <div class="ap-standard">AAP-2.J.1</div>
             <p>Los científicos de la computación definen una estructura de programa repetitivo como un <em>ciclo</em>, <em>repetición</em>, o <strong>iteración</strong> (<em>iteration</em>).</p>
             <div class="ap-standard">AAP-2.K.1</div>
@@ -135,17 +135,17 @@
         </div>
 <h3>Laboratorio 4: Proteger tu privacidad</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box9"><b>Laboratorio 4, página 1</b></a>: <strong>Información personal identificable (PII)</strong>
+<a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 1</b></a>: <strong>Información personal identificable (PII)</strong>
             <div class="ap-standard">IOC-2.A.1</div>
             <p><strong>Información personal identificable</strong> (<em>Personally identifiable information</em> o PII, por sus siglas en inglés) es la información que puede ser usada por otras personas para generar una idea que quién eres y obtener, posiblemente, más información como tu número de seguridad social, edad, raza, número(s) de teléfono, información médica, información financiera o incluso datos biométricos (huella dactilar o escaneo de las facciones de la cara).</p>
         </div>
 <h3>Laboratorio 5: Seguir un objeto</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box10"><b>Laboratorio 5, página 2</b></a>: <strong>Bucle infinito</strong>
+<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 5, página 2</b></a>: <strong>Bucle infinito</strong>
                         <p>Cuando un programa sigue haciendo lo mismo y nunca se detiene, se llama <strong>bucle infinito</strong> (<em>infinite loop</em>).</p>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html" id="box11"><b>Laboratorio 5, página 2</b></a>: <strong>Segmento de código</strong>
+<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.es.html?topic=nyc_bjc/1-intro-loops.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 5, página 2</b></a>: <strong>Segmento de código</strong>
                         <div class="ap-standard">CRD-2.B.2, AAP-2.B.2, AAP-2.B.6</div>
                         <p>Un <strong>segmento de código</strong> (<em>code segment</em>) es una secuencia de instrucciones conectadas que llevan a cabo una acción determinada, como la que se muestra a la izquierda, que anima una conversación. Las instrucciones en el segmento de código se llevan a cabo en orden, de arriba a abajo.</p>
                     </div>

--- a/cur/programming/1-introduction/unit-1-vocab.html
+++ b/cur/programming/1-introduction/unit-1-vocab.html
@@ -13,7 +13,7 @@
 <h2>Unit 1: Introduction to Programming</h2>
 <h3>Lab 1: Click Alonzo Game</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box0"><b>Lab 1, Page 4</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
+<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 4</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
             <p>The Alonzo character is named after Alonzo Church, a major contributor to early computer science. In this project, there are three objects related to Alonzo:
                 </p>
 <ul>
@@ -23,7 +23,7 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box1"><b>Lab 1, Page 4</b></a>: <strong>Transparency</strong>
+<a href="/bjc-r/cur/programming/1-introduction/1-building-an-app/4-keeping-score.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 4</b></a>: <strong>Transparency</strong>
             <p>
                 The <strong>transparency</strong> of an image is how much you can see what's behind it. For example, here is the Alonzo sprite shown with three different transparencies (which have been set using the <code>ghost effect</code> block).<br>
                 <img class="indent" src="/bjc-r/img/1-introduction/transparency2.png" title="three pictures of Alonzo, with ghost effect 0%, 25%, and 50%, on a background of a brick wall" alt="three pictures of Alonzo, with ghost effect 0%, 25%, and 50%, on a background of a brick wall">
@@ -31,7 +31,7 @@
         </div>
 <h3>Lab 2: Gossip</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box2"><b>Lab 2, Page 3</b></a>: <strong>Lists</strong>, <strong>Strings</strong>, and <strong>Concatenation</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 3</b></a>: <strong>Lists</strong>, <strong>Strings</strong>, and <strong>Concatenation</strong>
             <ul>
 				<!--<div class="index-term" id="report</code>"></div>-->
                 
@@ -57,11 +57,11 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box3"><b>Lab 2, Page 3</b></a>: <strong>Debugging</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/3-customizing.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 3</b></a>: <strong>Debugging</strong>
                     <p>The process of testing, finding problems, and fixing them is called <strong>debugging</strong>.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box4"><b>Lab 2, Page 4</b></a>: <strong>Procedures</strong>, <strong>Reporters</strong>, and <strong>Commands</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 4</b></a>: <strong>Procedures</strong>, <strong>Reporters</strong>, and <strong>Commands</strong>
             <div class="ap-standard">AAP-3.A.1, AAP-3.A.2</div>
             <p>
                 A <strong>procedure</strong> is a named sequence of instructions that may take inputs and may report a value. Some languages call procedures <em>methods</em> or <em>functions</em>. Here are two types of procedures you have seen in Snap<em>!</em>:
@@ -83,7 +83,7 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box5"><b>Lab 2, Page 5</b></a>: <strong>Expressions</strong> and <strong>Values</strong>
+<a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/5-if-else.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 5</b></a>: <strong>Expressions</strong> and <strong>Values</strong>
             <div class="ap-standard">AAP-2.B.3, AAP-2.B.4</div>
             <ul>
                 <li>An <strong>expression</strong> is a either a constant value (such as "4" or "winter") or a call to a reporter block including its inputs (such as <img class="inline" src="/bjc-r/img/2-complexity/number.png" alt="number" title="number">, <img class="inline nopadtb" src="/bjc-r/img/1-introduction/5+(4x3).png" alt="5 + (4 * 3)" title="5 + (4 * 3)">, or <img class="inline" src="/bjc-r/img/2-complexity/join-who-doeswhat-who.png" alt="join (who) ( ) (does what) ( ) (who)" title="join (who) ( ) (does what) ( ) (who)">).</li>
@@ -92,13 +92,13 @@
         </div>
 <h3>Lab 3: Modern Art with Polygons</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box6"><b>Lab 3, Page 1</b></a><strong>: Algorithm</strong> and <strong>Pseudocode</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/1-exploring-motion.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 1</b></a><strong>: Algorithm</strong> and <strong>Pseudocode</strong>
             <div class="ap-standard">AAP-2.A.1, AAP-2.A.2, AAP-2.A.3</div>
             <p>An <strong>algorithm</strong> is a sequence of steps that are usually performed by a computer. The algorithm doesn't have to be written in any particular programming language or even in a programming language at all; you can write your algorithm in English or any other human language. Some people call an algorithm written in human language <strong>pseudocode</strong>. Once you know the steps that the computer will take, you can code your algorithm in the programming language of your choice.</p>
             <div class="endnote">What's the purpose of "pseudocode"? Why write an algorithm vaguely in English when you could write it precisely in Snap<em>!</em>? If you were programming in a punctuation-heavy language, designing your program in pseudocode would help you focus on the important ideas instead of on details like quotation marks and semicolons. But pseudocode isn't as necessary with a language like Snap<em>!</em>, and pseudocode can make it easy for you to fall into wishful thinking about what the computer is capable of (such as writing "Pick tomorrow's winning lottery numbers" or "Here's the melody; write the harmony").</div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box7"><b>Lab 3, Page 3</b></a>: What's an input? <strong>Parameter</strong> vs. <strong>Argument</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/3-blocks-with-inputs.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 3</b></a>: What's an input? <strong>Parameter</strong> vs. <strong>Argument</strong>
             <div class="ap-standard">AAP-3.A.3</div>
             <p>
                 </p>
@@ -116,7 +116,7 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box8"><b>Lab 3, Page 6</b></a>: <strong>Iteration</strong>
+<a href="/bjc-r/cur/programming/1-introduction/3-drawing/6-the-for-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 6</b></a>: <strong>Iteration</strong>
             <div class="ap-standard">AAP-2.J.1</div>
             <p>Computer scientists describe a repeating program structure as <em>looping</em>, <em>repetition</em>, or <strong>iteration</strong>.</p>
             <div class="ap-standard">AAP-2.K.1</div>
@@ -136,17 +136,17 @@
         </div>
 <h3>Lab 4: Protecting Your Privacy</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box9"><b>Lab 4, Page 1</b></a>: <strong>Personally Identifiable Information (PII)</strong>
+<a href="/bjc-r/cur/programming/1-introduction/4-privacy/1-your-image-in-the-cloud.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Personally Identifiable Information (PII)</strong>
             <div class="ap-standard">IOC-2.A.1</div>
             <p>Information that can identify you as an individual is called <strong>personally identifiable information (PII)</strong>. It includes details that could reveal who you are—such as your Social Security number, age, race, phone number(s), medical information, financial information, or biometric data like a thumbprint or face scan.</p>
         </div>
 <h3>Lab 5: Follow the Leader</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box10"><b>Lab 5, Page 2</b></a>: <strong>Infinite Loop</strong>
+<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-1"><b>Lab 5, Page 2</b></a>: <strong>Infinite Loop</strong>
                         <p>When a program keeps running forever, that's called an <strong>infinite loop</strong>.</p>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html" id="box11"><b>Lab 5, Page 2</b></a>: <strong>Code Segment</strong>
+<a href="/bjc-r/cur/programming/1-introduction/5-follow-the-leader/2-sprite-interaction.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html#vocab-2"><b>Lab 5, Page 2</b></a>: <strong>Code Segment</strong>
                         <div class="ap-standard">CRD-2.B.2, AAP-2.B.2, AAP-2.B.6</div>
                         <p>A <strong>code segment</strong> is a sequence of connected instructions that carry out a purposeful action, such as the one pictured on the left, which animates a conversation.  The instructions in the code segment are carried out in order, from top to bottom.</p>
                     </div>

--- a/cur/programming/2-complexity/1-variables-games/3-debugging-extending.html
+++ b/cur/programming/2-complexity/1-variables-games/3-debugging-extending.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<script type="text/javascript" src="/bjc-r/llab/loader.js"></script>
 
-        <script type="text/javascript">window.onload = function() {Gifffer();};</script>	    <title>Unit 2 Lab 1: Games, Page 3</title>
+	    <title>Unit 2 Lab 1: Games, Page 3</title>
 	</head>
 
 	<body>

--- a/cur/programming/2-complexity/1-variables-games/4-keeping-score.html
+++ b/cur/programming/2-complexity/1-variables-games/4-keeping-score.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<script type="text/javascript" src="/bjc-r/llab/loader.js"></script>
 
-        <script type="text/javascript">window.onload = function() {Gifffer();};</script>	    <title>Unit 2 Lab 1: Games, Page 4</title>
+	    <title>Unit 2 Lab 1: Games, Page 4</title>
 	</head>
 
 	<body>

--- a/cur/programming/2-complexity/unit-2-exam-reference.es.html
+++ b/cur/programming/2-complexity/unit-2-exam-reference.es.html
@@ -11,12 +11,12 @@
 </head>
 <body>
 <h2>Laboratorio 1: Juegos</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box28"><strong>laboratorio 1, página 1</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 1</strong></a>
 			<div class="ap-standard">AAP-1.B.2</div>
 			<div class="pseudop">
 				<img class="inline" src="/bjc-r/img/2-complexity/set-secret-number-to-7.es.png" alt="set (secret number) to (7)" title="set (secret number) to (7)"> se escribiría como <pre class="inline">númeroSecreto &leftarrow; 7</pre> o <img class="nopadtb" src="/bjc-r/img/2-complexity/secret-number-assignment-blocktran.es.png" alt="un rectángulo blanco con el texto 'númeroSecreto &leftarrow; 7'" title="un rectángulo blanco con el texto 'númeroSecreto &leftarrow; 7'">.
 			</div>
-			</div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box32"><strong>laboratorio 1, página 2</strong></a>
+			</div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 2</strong></a>
             <div class="pseudop">
                 El código <img class="inline" src="/bjc-r/img/2-complexity/chicken-script.es.png" alt="preguntar (¿Por qué la gallina cruzó la calle?) y esperar; asignar a (respuesta de usuario) el valor (respuesta)" title="preguntar (¿Por qué la gallina cruzó la calle?) y esperar; asignar a (respuesta de usuario) el valor (respuesta)">
                 se escribiría como
@@ -26,43 +26,43 @@ respuestaUsuario &leftarrow; INPUT()</pre></div> o
             </div>
             <div class="ap-standard">AAP-3.A.8, AAP-3.A.9</div>
             <div class="pseudop">Observa que el procedimiento <pre class="inline">INPUT()</pre> (Entrada) acepta el valor del usuario y devuelve ese valor de entrada, que luego se asigna a la variable <pre class="inline">respuestaUsuario</pre> con la <pre class="inline">&leftarrow;</pre> sintaxis. En Snap<em>!</em>, así es cómo <code>respuesta</code> acepta un valor del usuario y lo reporta, y ese reporte es a lo que la computadora <code>asigna</code> la variable <var>respuesta del usuario</var>.</div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box33"><strong>laboratorio 1, página 4</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 4</strong></a>
                                 <div class="pseudop">
                                     <img class="inline nopadtb" src="/bjc-r/img/2-complexity/change-score-by-1.es.png" alt="incrementar (puntuación) en (1)" title="incrementar (puntuación) en (1))"> (lo que significa <img src="/bjc-r/img/2-complexity/set-score-to-score-plus-one.es.png" alt="asignar a(puntuación) el valor (puntuación+1)" title="asignar a(puntuación) el valor (puntuación+1)">) se escribiría como <pre class="inline">puntuación &leftarrow; puntuación + 1</pre> o <img class="inline" src="/bjc-r/img/2-complexity/score-increment-blocktran.es.png" alt="puntuación ← puntuación + 1" title="puntuación ← puntuación + 1">.
                                 </div>
-                            </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box35"><strong>laboratorio 1, página 5</strong></a>
+                            </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 5</strong></a>
             <div class="ap-standard">AAP-2.N.1 viñeta 1</div>
             <div class="pseudop">
                 La expresión de lista <img class="inline" src="/bjc-r/img/2-complexity/item-2-of-costumes.es.png" alt="elemento (2) de (disfraces)" title="elemento (2) de (disfraces)"> se escribiría como <pre class="inline">disfraces[2]</pre> o <img class="inline" src="/bjc-r/img/2-complexity/accessing-blocktran.es.png" alt="disfraces[2]" title="disfraces[2]">. Las tres versiones de este código reportarían/devolverían el disfraz de pingüino (si el lenguaje AP tuviera disfraces como tipo de datos):<br>
                 <img class="indent" src="/bjc-r/img/2-complexity/item-2-of-costumes-reporting-penguin.es.png" alt="elemento (2) de (disfraces) reporta una imagen del disfraz de pingüino" title="elemento (2) de (disfraces) reporta un disfraz de una imagen del disfraz de pingüino">
             </div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box36"><strong>laboratorio 1, página 5</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-2"><strong>laboratorio 1, página 5</strong></a>
             <div class="ap-standard">AAP-2.N.1 viñeta 7</div>
             <div class="pseudop">
                 La expresión <img class="inline" src="/bjc-r/img/2-complexity/example-length.es.png" alt="longitud de (lista de palabras)" title="longitud de (lista de palabras)"> se escribiría como <pre class="inline">LENGTH(listaPalabras)</pre> o <img class="inline" src="/bjc-r/img/2-complexity/length-blocktran.es.png" alt="LENGTH(listaPalabras)" title="LENGTH(listaPalabras)">.
             </div>
         </div><h2>Laboratorio 2: Elaboración de listas</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box37"><strong>laboratorio 2, página 1</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 2, página 1</strong></a>
             <div class="ap-standard">AAP-1.C.1 segunda oración, AAP-1.D.7</div>
             <div class="pseudop">La expresión de lista <img class="inline" src="/bjc-r/img/1-introduction/list-from-who.es.png" alt="lista{Señora, Sra. C, mi gato, Hannah, Jake}" title="lista{Señora, Sra. C, mi gato, Hannah, Jake}"> se escribiría como <pre class="inline">[Señora, Sra. C, mi gato, Hannah, Jake]</pre>. Los elementos se colocan en la lista en el orden en que aparecen en el texto: "Señora" tiene el índice 1, "Sra. C" tiene el índice 2, y así sucesivamente.</div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box38"><strong>laboratorio 2, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-2"><strong>laboratorio 2, página 1</strong></a>
             <div class="ap-standard">AAP-1.D.7 viñeta 2</div>
             <div class="pseudop">La instrucción de asignación <img class="inline" src="/bjc-r/img/2-complexity/example-blank-list-assignment.es.png" alt="asignar a (lista de la compra) el valor (lista)" title="asignar a (lista de la compra) el valor (lista)"> se escribiría como <pre class="inline">listaDeCompras &leftarrow; []</pre> o <img class="" src="/bjc-r/img/2-complexity/shoppinglist-empty-list-assignment-blocktran.es.png" alt="listaDeCompras ← []" title="listaDeCompras ← []">.</div>
             <div class="ap-standard">AAP-1.D.7 viñeta 1</div>
             <div class="pseudop">La instrucción de asignación <img class="inline" src="/bjc-r/img/2-complexity/example-list-assignment.es.png" alt="asignar a (lista de la compra) el valor {manzanas, pan, zanahorias, arroz, pasta}" title="asignar a (lista de la compra) el valor {manzanas, pan, zanahorias, arroz, pasta}"> se escribiría como <pre class="inline">listaDeCompras &leftarrow; [manzanas, pan, zanahorias, arroz, pasta]</pre> o <img class="" src="/bjc-r/img/2-complexity/shoppinglist-full-list-assignment-blocktran.es.png" alt="listaDeCompras ← [manzanas, pan, zanahorias, arroz, pasta]" title="listaDeCompras ← [manzanas, pan, zanahorias, arroz, pasta]">. (En esta aplicación, deseará que la <code>lista de la compra</code> comience vacía, y luego el usuario <code>agregue</code> o <code>inserte</code> más artículos comestibles de uno en uno.)</div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box39"><strong>laboratorio 2, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-3"><strong>laboratorio 2, página 1</strong></a>
             <div class="ap-standard">AAP-2.N.1 viñeta 4</div>
             <div class="pseudop">
 <img class="inline" src="/bjc-r/img/2-complexity/insert-tomatoes-at-2-of-shopping-list.es.png" alt="añadir (tomate) a (lista de la compra)" title="añadir (tomate) a (lista de la compra)"> se escribiría como <pre class="inline">INSERT(listaDeCompras, 2, "tomate")</pre> o <img class="inline" src="/bjc-r/img/2-complexity/insert-blocktran.es.png" alt="INSERT(listaDeCompras, 2, 'tomate')" title="INSERT(listaDeCompras, 2, 'tomate')">.</div>
             <div class="pseudop">
 <img class="inline" src="/bjc-r/img/2-complexity/add-tomatoes-to-shopping-list.es.png" alt="añadir (tomate) a (lista de la compra)" title="añadir (tomate) a (lista de la compra)"> se escribiría como <pre class="inline">APPEND(listaDeCompras, "tomate")</pre> o <img class="inline" src="/bjc-r/img/2-complexity/add-blocktran.es.png" alt="APPEND(listaDeCompras, 'tomate')" title="APPEND(listaDeCompras,'tomate')">.</div>
             <div class="ap-standard">AAP-2.N.1 viñeta 5</div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box40"><strong>laboratorio 2, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-4"><strong>laboratorio 2, página 1</strong></a>
             <div class="pseudop">
                 <div class="ap-standard">AAP-2.N.1 viñeta 6</div>
                 <img class="inline" src="/bjc-r/img/2-complexity/delete-item-2-of-shopping-list.es.png" alt="borrar (2) de (lista de la compra)" title="borrar (2) de (lista de la compra)"> se escribiría como <pre class="inline">REMOVE(listaDeCompras, 2)</pre> o <img class="inline" src="/bjc-r/img/2-complexity/remove-blocktran.es.png" alt="REMOVE(listaDeCompras, 2)" title="REMOVE(listaDeCompras, 2)">.
             </div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box41"><strong>laboratorio 2, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-5"><strong>laboratorio 2, página 1</strong></a>
             <div class="pseudop">
                 Los elementos de una lista son <em>valores</em>, por lo que <strong>puedes usar <code>elemento de</code> en cualquier lugar donde puedas usar cualquier otra expresión</strong>. Por ejemplo:
                 <div class="ap-standard">AAP-2.N.1 viñeta 2 y 3</div>
@@ -93,7 +93,7 @@ respuestaUsuario &leftarrow; INPUT()</pre></div> o
                     </li>
                 </ul>
             </div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box42"><strong>laboratorio 2, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-6"><strong>laboratorio 2, página 1</strong></a>
             <p>
                 Cuando ejecutas este programa en Snap<em>!</em>, la segunda línea de código asigna a <var>lista de la compra 2</var> el valor de <var>lista de la compra</var> (es decir, la misma lista, no una copia). Por eso, la tercera línea de código modifica <em>ambas</em> variables: <br>
                 <img class="indent" src="/bjc-r/img/2-complexity/example-list-by-reference.es.png" alt="asignar a (lista de la compra) a (lista(manzana)(plátano))
@@ -106,7 +106,7 @@ añadir (zanahoria) a (lista de la compra)">
             <div class="ap-standard">AAP-1.D.7 viñeta 3, AAP-2.N.2</div>
             <div class="pseudop">Sin embargo, en el examen, el enunciado <pre class="inline">listaDeCompras2 &leftarrow; listaDeCompras</pre> hace una <em>copia</em> de la lista. Así que al modificar uno de ellos <em>no</em> se modifica el otro.</div>
             <p>Las reglas sobre cómo usar las listas y cómo se comportan difieren según el lenguaje de programación que estés usando.</p>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box47"><strong>laboratorio 2, página 3</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 2, página 3</strong></a>
             <div class="ap-standard">AAP-2.O.3</div>
             <div class="pseudop">
                 <div class="sidenote">El procedimiento <pre class="inline">irA()</pre> no está integrado en el lenguaje del AP, por eso está escrito en minúsculas como otros procedimientos definidos por el programador.</div>
@@ -125,7 +125,7 @@ añadir (zanahoria) a (lista de la compra)">
 }">.
             </div>
         </div><h2>Laboratorio 3: Tomar decisiones</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box50"><strong>laboratorio 3, página 1</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 3, página 1</strong></a>
             <div class="ap-standard">AAP-2.E.2</div>
             <div class="pseudop">
                 Puedes ver estos cinco operadores relacionales: <pre class="inline">=, &gt;, &lt;, ≥, ≤</pre> así como un sexto: <pre class="inline">≠</pre>, que significa "distinto a" y reporta <code>falso</code> si las dos entradas son iguales y, de lo contrario, reporta <code>verdadero</code> (si no son iguales). Cuando escribes el bloque de <img class="inline" src="/bjc-r/img/2-complexity/not-equal.png" alt="() distinto a ()" title="() distinto a ()"> , funcionará así:<br>
@@ -133,11 +133,11 @@ añadir (zanahoria) a (lista de la compra)">
                 <img class="indent" src="/bjc-r/img/2-complexity/not-equal-reporting-false.es.png" alt="(3) distinto a(3) reporta falso" title="(3) distinto a (3) reporta falso">
             </div>
             <p>Estos seis operadores relacionales reportan un valor booleano (<code>verdadero</code> o <code>falso</code>).</p>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box53"><strong>laboratorio 3, página 2</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 3, página 2</strong></a>
             <div class="ap-standard">AAP-2.F.1</div>
             <div class="pseudop">Los bloques <img src="/bjc-r/img/blocks/and-full-size.es.png" alt="() y ()" title="() y ()">, <img src="/bjc-r/img/blocks/or.es.png" alt="() o ()" title="() o ()">, y <img src="/bjc-r/img/blocks/not.es.png" alt="no ()" title="no ()"> aparecerán en inglés como <pre class="inline">AND</pre>, <pre class="inline">OR</pre> y <pre class="inline">NOT</pre> y funcionarán exactamente de la misma manera que lo hacen en Snap<em>!</em>.</div>
         </div><h2>Laboratorio 4: Matemáticas con computadoras</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box59"><strong>laboratorio 4, página 1</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 4, página 1</strong></a>
             <div class="pseudop">
                 <div class="sidenote">Los distintos lenguajes de programación tienen diferentes formas de manejar entradas negativas a la función módulo. Por lo tanto, no verás ningún uso de módulo con un número negativo en el examen.</div>
                 <strong>El operador <code>módulo</code></strong> ("mod", en inglés): la expresion <img class="inline nopadtb" src="/bjc-r/img/1-introduction/17-mod-5.es.png" alt="(17) módulo (5)" title="(17) módulo (5)"> se escribiría en inglés como <pre class="inline">17 MOD 5</pre> en el examen. Si ves una expresión con variables como entrada para <code>módulo</code>, tal como <pre class="inline">a MOD b</pre>, puedes asumir que <var>a</var> es cero o positivo, y <var>b</var> es estrictamente positivo (porque no se puede dividir por 0).
@@ -148,7 +148,7 @@ añadir (zanahoria) a (lista de la compra)">
             <div class="pseudop">
 <strong>Orden de operaciones:</strong> En un lenguaje de bloques, la anidación de bloques determina el orden de las operaciones. Por ejemplo, en <img class="inline nopadtb" src="/bjc-r/img/6-computers/3-times(5+4).png" alt="3 × (5 + 4)" title="3 × (5 + 4)"> puedes <em>ver</em> que el bloque <code>+</code> es una entrada al bloque <code>×</code>, entonces la expresión significa 3×(5+4). De manera similar, <img class="inline nopadtb" src="/bjc-r/img/6-computers/(3-times-5)+4.png" alt="(3 × 5) + 4" title="(3 × 5) + 4"> significa (3×5)+4. En Snap<em>!</em>, es como si hubiera paréntesis alrededor de <em>todas</em> las operaciones. Pero en lenguajes de texto, puedes escribir <pre class="inline">3 * 4 + 5</pre>
                 sin paréntesis, entonces ahí sí necesitas las reglas que aprendiste en la clase de matemáticas (multiplicación antes de la suma, etc.). El operador <code>módulo</code> es como la multiplicación y la división; ocurre <em>antes</em> de la suma y la resta. Así por ejemplo, <pre class="inline">7 + 5 MOD 2 - 6</pre> significa <pre class="inline">7 + 1 - 6</pre>, que es, por supuesto, 2.</div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box60"><strong>laboratorio 4, página 1</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-2"><strong>laboratorio 4, página 1</strong></a>
             <div class="ap-standard">AAP-2.H.2</div>
             <div class="sidenote">
                 <div class="pseudop">Los procedimientos <pre class="inline">mover()</pre> y <pre class="inline">girar_sentidoreloj()</pre> no están integrados en el lenguaje del AP y por eso que se escriben en letras minúsculas al igual que otros procedimientos definidos por un programador.</div>
@@ -186,7 +186,7 @@ IF(tamaño &gt; 15)
 }">
             </div>
             <p>Como en Snap<em>!</em>, si la condición <code>(</code><var>tamaño</var><code>) &gt; 15</code> es <code>verdadero</code>, se ejecuta el código dentro de la instrucción <code>si</code>; pero si la condición es <code>falso</code>, el código no se ejecuta.</p>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box62"><strong>laboratorio 4, página 3</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 4, página 3</strong></a>
             <div class="ap-standard">AAP-3.C.2</div>
             <div class="sidenote">Viste la definición de procedimiento para un comando en<a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.es.html?topic=nyc_bjc%2F1-intro-loops.es.topic&course=bjc4nyc.es.html&novideo&noassignment" title="Unidad 1 Laboratorio 3, Página 4: Modifica tu molinete" target="_blank">Unidad 1 Laboratorio 3, Página 4: Modifica tu molinete</a>.</div>
             <div class="pseudop">
@@ -209,7 +209,7 @@ PROCEDURE raízCuadrada(número)
                     <div class="pseudop">También, el procedimiento <pre class="inline">sqrt</pre> (abreviatura de <em>square root</em>, raíz cuadrada en inglés) no está integrado en el lenguaje del AP, es por eso que está escrito en minúsculas como otros procedimientos definidos por un programador.</div>
                 </div>
             </div>
-        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box63"><strong>laboratorio 4, página 3</strong></a>
+        </div><div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#exam-2"><strong>laboratorio 4, página 3</strong></a>
             <div class="ap-standard">AAP-2.H.3</div>
             <div class="pseudop">La expresión condicional <img class="inline" src="/bjc-r/img/2-complexity/ge-ifelse-no-hat.es.png" alt="si (a &gt; b) {
     reportar verdadero

--- a/cur/programming/2-complexity/unit-2-exam-reference.html
+++ b/cur/programming/2-complexity/unit-2-exam-reference.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Lab 1: Games</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box27"><strong>Lab 1, Page 1</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 1</strong></a>
             <div class="python">
 				<a href="#hint-python-2-1-1-1" data-bs-toggle="collapse" title="What would this look like in Python?">What would this look like in Python?</a>
 				<div id="hint-python-2-1-1-1" class="collapse">
@@ -23,7 +23,7 @@
             <div class="pseudop">
                 <img class="inline" src="/bjc-r/img/2-complexity/set-secret-number-to-7.png" alt="set (secret number) to (7)" title="set (secret number) to (7)"> would be written as <pre class="inline">secretNumber &leftarrow; 7</pre> or <img class="nopadtb" src="/bjc-r/img/2-complexity/secret-number-assignment-blocktran.png" alt="a white rounded rectangle containing the text 'secretNumber &leftarrow; 7'" title="a white rounded rectangle containing the text 'secretNumber &leftarrow; 7'">.
             </div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box31"><strong>Lab 1, Page 2</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 2</strong></a>
             <div class="pseudop">
                 The code <img class="inline" src="/bjc-r/img/2-complexity/chicken-script.png" alt="ask (Why did the chicken cross the road?) and wait; set (user response) to (answer)" title="ask (Why did the chicken cross the road?) and wait; set (user response) to (answer)">
                 would be written as
@@ -41,7 +41,7 @@ input = prompt("Why did the chicken cross the road?")
 userResponse = input</code></pre>
 				</div>
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box32"><strong>Lab 1, Page 4</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 4</strong></a>
                                 <div class="pseudop">
 									<div class="python">
 										<a href="#hint-python-2-1-4-1" data-bs-toggle="collapse" title="What would this look like in Python?">What would this look like in Python?</a>
@@ -51,19 +51,19 @@ userResponse = input</code></pre>
 									</div>
                                     <img class="inline nopadtb" src="/bjc-r/img/2-complexity/change-score-by-1.png" alt="change (score) by (1)" title="change (score) by (1)"> (which means <img src="/bjc-r/img/2-complexity/set-score-to-score-plus-one.png" alt="set(score) to (score+1)" title="set(score) to (score+1)">) would be written as <pre class="inline">score &leftarrow; score + 1</pre> or <img class="inline" src="/bjc-r/img/2-complexity/score-increment-blocktran.png" alt="score ← score + 1" title="score ← score + 1">.
                                 </div>
-                            </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box34"><strong>Lab 1, Page 5</strong></a>
+                            </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 5</strong></a>
             <div class="ap-standard">AAP-2.N.1 bullet 1</div>
             <div class="pseudop">
                 The list expression <img class="inline" src="/bjc-r/img/2-complexity/item-2-of-costumes.png" alt="item (2) of (costumes)" title="item (2) of (costumes)"> would be written as <pre class="inline">costumes[2]</pre> or <img class="inline" src="/bjc-r/img/2-complexity/accessing-blocktran.png" alt="costumes[2]" title="costumes[2]">. All three versions of this code would report/return the penguin costume (if only the AP language had costumes as a data type):<br>
                 <img class="indent" src="/bjc-r/img/2-complexity/item-2-of-costumes-reporting-penguin.png" alt="item (2) of (costumes) reporting a picture of the penguin costume" title="item (2) of (costumes) reporting a picture of the penguin costume">
             </div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box35"><strong>Lab 1, Page 5</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-2"><strong>Lab 1, Page 5</strong></a>
             <div class="ap-standard">AAP-2.N.1 bullet 7</div>
             <div class="pseudop">
                 The expression <img class="inline" src="/bjc-r/img/2-complexity/example-length.png" alt="length of (words list)" title="length of (words list)"> would be written as <pre class="inline">LENGTH(wordsList)</pre> or <img class="inline" src="/bjc-r/img/2-complexity/length-blocktran.png" alt="LENGTH(wordsList)" title="LENGTH(wordsList)">.
             </div>
         </div><h2>Lab 2: Making Lists</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box36"><strong>Lab 2, Page 1</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 2, Page 1</strong></a>
             <div class="ap-standard">AAP-1.C.1 second sentence, AAP-1.D.7</div>
             <div class="pseudop">
 				<div class="python">
@@ -74,7 +74,7 @@ userResponse = input</code></pre>
 				</div>
 				The list expression <img class="inline" src="/bjc-r/img/1-introduction/list-from-who.png" alt="list{Señora, Ms. C, my cat, Hannah, Jake}" title="list{Señora, Ms. C, my cat, Hannah, Jake}"> would be written as <pre class="inline">[Señora, Ms. C, my cat, Hannah, Jake]</pre>. The items are positioned in the list in the order they appear in the text: "Señora" has index 1, "Ms. C" has index 2, and so on.
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box37"><strong>Lab 2, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-2"><strong>Lab 2, Page 1</strong></a>
             <div class="ap-standard">AAP-1.D.7 bullet 2</div>
             <div class="pseudop">
 				<div class="python">
@@ -95,7 +95,7 @@ userResponse = input</code></pre>
 				</div>
 				The assignment instruction <img class="inline" src="/bjc-r/img/2-complexity/example-list-assignment.png" alt="set (shopping list) to {apples, bread, carrots, rice, pasta}" title="set (shopping list) to {apples, bread, carrots, rice, pasta}"> would be written as <pre class="inline">shoppingList &leftarrow; [apples, bread, carrots, rice, pasta]</pre> or <img class="" src="/bjc-r/img/2-complexity/shoppinglist-full-list-assignment-blocktran.png" alt="shoppingList ← [apples, bread, carrots, rice, pasta]" title="shoppingList ← [apples, bread, carrots, rice, pasta]">. (In this app, you'll want the <code>shopping list</code> to begin empty, and then the user will <code>add</code> or <code>insert</code> additional grocery items one at a time.)
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box38"><strong>Lab 2, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-3"><strong>Lab 2, Page 1</strong></a>
             <div class="ap-standard">AAP-2.N.1 bullet 4</div>
             <div class="pseudop">
 				<div class="python">
@@ -129,7 +129,7 @@ userResponse = input</code></pre>
 					<img class="" src="/bjc-r/img/2-complexity/shopping-list-3.png" alt='{"apples", "bread", "carrots", "rice", "pasta", "tomatoes"}' title='{"apples", "bread", "carrots", "rice", "pasta", "tomatoes"}'>
 				</div>
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box39"><strong>Lab 2, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-4"><strong>Lab 2, Page 1</strong></a>
             <div class="pseudop">
                 <div class="ap-standard">AAP-2.N.1 bullet 6</div>
 				<div class="python">
@@ -140,7 +140,7 @@ userResponse = input</code></pre>
 				</div>
                 <img class="inline" src="/bjc-r/img/2-complexity/delete-item-2-of-shopping-list.png" alt="delete item (2) of (shopping list)" title="delete item (2) of (shopping list)"> would be written as <pre class="inline">REMOVE(shoppingList, 2)</pre> or <img class="inline" src="/bjc-r/img/2-complexity/remove-blocktran.png" alt="REMOVE(shoppingList, 2)" title="REMOVE(shoppingList, 2)">.
             </div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box40"><strong>Lab 2, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-5"><strong>Lab 2, Page 1</strong></a>
             <div class="pseudop">
                 The items in a list are <em>values</em>, so <strong>you can use <code>item of</code> anywhere you can use any other expression</strong>. For example:
                 <div class="ap-standard">AAP-2.N.1 bullets 2 and 3</div>
@@ -171,7 +171,7 @@ userResponse = input</code></pre>
                     </li>
                 </ul>
             </div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box41"><strong>Lab 2, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-6"><strong>Lab 2, Page 1</strong></a>
             <p>
                 When you run this script in Snap<em>!</em>, the second line of code assigns to <var>shopping list 2</var> the value of <var>shopping list</var> (that is, the same list, not a copy). So, the third line of code modifies <em>both</em> variables: <br>
                 <img class="indent" src="/bjc-r/img/2-complexity/example-list-by-reference.png" alt="set(shopping list) to (list(apple)(banana))
@@ -194,7 +194,7 @@ shoppingList1.append("carrot")
 					</code></pre>
 				</div>
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box46"><strong>Lab 2, Page 3</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 2, Page 3</strong></a>
             <div class="ap-standard">AAP-2.O.3</div>
             <div class="pseudop">
                 <div class="sidenote">The procedure <pre class="inline">goto()</pre> isn't built in to the AP's language so it is written in lower case like other programmer-defined procedures.</div>
@@ -223,7 +223,7 @@ for each point in myDrawing:
 				</div>
 			</div>
         </div><h2>Lab 3: Making Decisions</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box49"><strong>Lab 3, Page 1</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 3, Page 1</strong></a>
             <div class="ap-standard">AAP-2.E.2</div>
             <div class="pseudop">
                 You may see these five relational operators: <pre class="inline">=, &gt;, &lt;, ≥, ≤</pre> as well as a sixth: <pre class="inline">≠</pre>, which means "not-equal" and reports <code>false</code> if the two inputs are equal and otherwise reports <code>true</code> (if they are not equal). When you write the <img class="inline" src="/bjc-r/img/2-complexity/not-equal.png" alt="() not equal ()" title="() not equal ()"> block, it will work like this:<br>
@@ -237,11 +237,11 @@ for each point in myDrawing:
                 <img class="indent" src="/bjc-r/img/2-complexity/not-equal-reporting-false.png" alt="(3) not equal (3) reporting false" title="(3) not equal (3) reporting false">
             </div>
             <p>These six relational operators all report a Boolean value (<code>true</code> or <code>false</code>).</p>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box52"><strong>Lab 3, Page 2</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 3, Page 2</strong></a>
             <div class="ap-standard">AAP-2.F.1</div>
             <div class="pseudop">The <img src="/bjc-r/img/blocks/and-full-size.png" alt="() and ()" title="() and ()">, <img src="/bjc-r/img/blocks/or.png" alt="() or ()" title="() or ()">, and <img src="/bjc-r/img/blocks/not.png" alt="not ()" title="not ()"> blocks will appear as <pre class="inline">AND</pre>, <pre class="inline">OR</pre>, and <pre class="inline">NOT</pre> and will work exactly the same way as they do in Snap<em>!</em>.</div>
         </div><h2>Lab 4: Making Computers Do Math</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box58"><strong>Lab 4, Page 1</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 4, Page 1</strong></a>
             <div class="pseudop">
                 <div class="sidenote">Different programming languages have different ways of handling negative inputs to the mod function. So you won't see any negative numbers used with mod on the exam.</div>
                 <strong>The <code>mod</code> operator:</strong> The expression <img class="inline nopadtb" src="/bjc-r/img/1-introduction/17-mod-5.png" alt="(17) mod (5)" title="(17) mod (5)"> would be written as <pre class="inline">17 MOD 5</pre> on the exam. If you see an expression with variables as input to <code>mod</code>, such as <pre class="inline">a MOD b</pre>, you can assume that <var>a</var> is zero or positive, and <var>b</var> is strictly positive (because you can't divide by 0).
@@ -267,7 +267,7 @@ for each point in myDrawing:
 					</code></pre>
 				</div>
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box59"><strong>Lab 4, Page 1</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-2"><strong>Lab 4, Page 1</strong></a>
             <div class="ap-standard">AAP-2.H.2</div>
             <div class="sidenote">
                 <div class="pseudop">The procedures <pre class="inline">move()</pre> and <pre class="inline">turn_clockwise()</pre> aren't built in to the AP's language so they are written in lower case like other programmer-defined procedures.</div>
@@ -316,7 +316,7 @@ if size &gt; 15:
 					</code></pre>
 				</div>
 			</div>
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box61"><strong>Lab 4, Page 3</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-1"><strong>Lab 4, Page 3</strong></a>
             <div class="ap-standard">AAP-3.C.2</div>
             <div class="sidenote">You saw the procedure definition for a command in <a href="/bjc-r/cur/programming/1-introduction/3-drawing/4-modify-your-pinwheel.html?topic=nyc_bjc%2F1-intro-loops.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 1 Lab 3 Page 4: Modify Your Pinwheel" target="_blank">Unit 1 Lab 3 Page 4: Modify Your Pinwheel</a>.</div>
             <div class="pseudop">
@@ -351,7 +351,7 @@ def squareRoots(number):
 				</div>
 			</div>
 
-        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box62"><strong>Lab 4, Page 3</strong></a>
+        </div><div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#exam-2"><strong>Lab 4, Page 3</strong></a>
             <div class="ap-standard">AAP-2.H.3</div>
             <div class="pseudop">The conditional expression <img class="inline" src="/bjc-r/img/2-complexity/ge-ifelse-no-hat.png" alt="if (a &gt; b) {
     report true

--- a/cur/programming/2-complexity/unit-2-self-check.es.html
+++ b/cur/programming/2-complexity/unit-2-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Juegos</h2>
 <div class="assessment-data" type="multiplechoice" identifier="¿Qué valor mostrará este código?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_1_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box26"><strong>laboratorio 1, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 1</strong></a>
 </div>
 
 						<div class="prompt">
@@ -53,7 +53,7 @@ DISPLAY(b)</pre>
 						</div>
 					</div><div class="assessment-data" type="multiplechoice" identifier="¿Qué valor reportará este guion?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_1_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box27"><strong>laboratorio 1, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 1</strong></a>
 </div>
 
 						<div class="prompt">
@@ -90,7 +90,7 @@ DISPLAY(b)</pre>
 						</div>
 					</div><div class="assessment-data" type="multiplechoice" identifier="¿Qué entradas a función misteriosa reportarán 'terminado'?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_1_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box29"><strong>laboratorio 1, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -135,7 +135,7 @@ reportar (terminado)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Qué entradas a función misteriosa reportarán 'terminado'?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_1_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box30"><strong>laboratorio 1, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -192,7 +192,7 @@ reportar (terminado)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Qué entradas a función misteriosa reportarán 'terminado'?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_1_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box31"><strong>laboratorio 1, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 1, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -241,7 +241,7 @@ reportar (terminado)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="length3" hasinlinefeedback="true" maxchoices="3" responseidentifier="ri1_2_1_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box34"><strong>laboratorio 1, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -291,7 +291,7 @@ reportar (terminado)">
                     </div><h2>Laboratorio 2: Elaboración de listas</h2>
 <div class="assessment-data" type="multiplechoice" identifier="capitals" hasinlinefeedback="true" maxchoices="8" responseidentifier="ri1_2_2_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box43"><strong>laboratorio 2, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -375,7 +375,7 @@ reportar (terminado)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="abe" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri1_2_2_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box44"><strong>laboratorio 2, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -426,7 +426,7 @@ reportar (terminado)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="FOR EACH positive and square over 4" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_2_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box45"><strong>laboratorio 2, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 2, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -473,7 +473,7 @@ FOR EACH elemento IN listaEntradas
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Mystery Procedure" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_2_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box46"><strong>laboratorio 2, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 2, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -524,7 +524,7 @@ Misterio(misNotasMatemáticas, 60)
                     </div><h2>Laboratorio 3: Tomar decisiones</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Consider the code segment; what will be the output?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box48"><strong>laboratorio 3, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -562,7 +562,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Do the following code segments produce the same output" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_3_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box49"><strong>laboratorio 3, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 3, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -600,7 +600,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What's equivalent to num less than or equal to 23?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri1_2_3_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box51"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -636,7 +636,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which expression will report TRUE?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_3_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box52"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -667,7 +667,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Temperature humidity weather application" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box54"><strong>laboratorio 3, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -705,7 +705,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What goes in gray ring?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box55"><strong>laboratorio 3, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -742,7 +742,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which items in mystery list?" hasinlinefeedback="true" maxchoices="8" responseidentifier="ri2_2_3_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box56"><strong>laboratorio 3, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 3, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -807,7 +807,7 @@ Misterio(misNotasMatemáticas, 60)
                     </div><h2>Laboratorio 4: Matemáticas con computadoras</h2>
 <div class="assessment-data" type="multiplechoice" identifier="¿Cuál es la condición que falta para un predicado '¿impar?'?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_4_1" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box57"><strong>laboratorio 4, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -861,7 +861,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What's the value of 11 MOD (2 + 3)?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_4_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box58"><strong>laboratorio 4, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 4, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -897,7 +897,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the value of x?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri5_2_4_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box61"><strong>laboratorio 4, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -945,7 +945,7 @@ Misterio(misNotasMatemáticas, 60)
                     </div><h2>Laboratorio 5: Derechos de autor</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which describes intellectual property violated?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/1-copyright.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box64"><strong>laboratorio 5, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/1-copyright.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 5, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -981,7 +981,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Open access vs open source" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box65"><strong>laboratorio 5, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 5, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -1017,7 +1017,7 @@ Misterio(misNotasMatemáticas, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Imagine Streamshare legal issues" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/4-digital.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#box66"><strong>laboratorio 5, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/4-digital.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 5, página 4</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/2-complexity/unit-2-self-check.html
+++ b/cur/programming/2-complexity/unit-2-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Games</h2>
 <div class="assessment-data" type="multiplechoice" identifier="What value will this code return?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_1_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box25"><strong>Lab 1, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -53,7 +53,7 @@ DISPLAY(b)</pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What value will this script report?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_1_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box26"><strong>Lab 1, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -90,7 +90,7 @@ DISPLAY(b)</pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which inputs to mystery function will give the output finished?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_1_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box28"><strong>Lab 1, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 2</strong></a>
 </div>
 
 						<div class="prompt">
@@ -139,7 +139,7 @@ report (finished)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which inputs to mystery function will give the output finished?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_1_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box29"><strong>Lab 1, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -196,7 +196,7 @@ report (finished)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which inputs to mystery function will give the output finished?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_1_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box30"><strong>Lab 1, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 1, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -245,7 +245,7 @@ report (finished)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="length3" hasinlinefeedback="true" maxchoices="3" responseidentifier="ri1_2_1_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box33"><strong>Lab 1, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -295,7 +295,7 @@ report (finished)">
                     </div><h2>Lab 2: Making Lists</h2>
 <div class="assessment-data" type="multiplechoice" identifier="capitals" hasinlinefeedback="true" maxchoices="8" responseidentifier="ri1_2_2_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box42"><strong>Lab 2, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -379,7 +379,7 @@ report (finished)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="abe" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri1_2_2_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box43"><strong>Lab 2, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -430,7 +430,7 @@ report (finished)">
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="FOR EACH positive and square over 4" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_2_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box44"><strong>Lab 2, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 2, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -477,7 +477,7 @@ FOR EACH item IN inputList
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Mystery Procedure" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_2_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box45"><strong>Lab 2, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 2, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -528,7 +528,7 @@ Mystery(myMathGrades, 60)
                     </div><h2>Lab 3: Making Decisions</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Consider the code segment; what will be the output?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box47"><strong>Lab 3, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -566,7 +566,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Do the following code segments produce the same output" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_3_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box48"><strong>Lab 3, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 3, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -604,7 +604,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What's equivalent to num less than or equal to 23?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri1_2_3_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box50"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -640,7 +640,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which expression will report TRUE?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_3_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box51"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/2-combining-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -671,7 +671,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Temperature humidity weather application" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box53"><strong>Lab 3, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -709,7 +709,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What goes in gray ring?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_3_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box54"><strong>Lab 3, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -746,7 +746,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which items in mystery list?" hasinlinefeedback="true" maxchoices="8" responseidentifier="ri2_2_3_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box55"><strong>Lab 3, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 3, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -811,7 +811,7 @@ Mystery(myMathGrades, 60)
                     </div><h2>Lab 4: Making Computers Do Math</h2>
 <div class="assessment-data" type="multiplechoice" identifier="What's the missing condition for an ODD? predicate?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_2_4_1" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box56"><strong>Lab 4, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -865,7 +865,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What's the value of 11 MOD (2 + 3)?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_2_4_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box57"><strong>Lab 4, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/1-mod-operator.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 4, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -901,7 +901,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the value of x?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri5_2_4_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box60"><strong>Lab 4, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/3-other-math-reporters.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -949,7 +949,7 @@ Mystery(myMathGrades, 60)
                     </div><h2>Lab 5: Copyrights</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which describes intellectual property violated?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/1-copyright.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box63"><strong>Lab 5, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/1-copyright.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 5, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -985,7 +985,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Open access vs open source" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box64"><strong>Lab 5, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 5, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -1021,7 +1021,7 @@ Mystery(myMathGrades, 60)
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Imagine Streamshare legal issues" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_2_5_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/4-digital.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#box65"><strong>Lab 5, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/2-complexity/5-copyrights/4-digital.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 5, Page 4</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/2-complexity/unit-2-vocab.es.html
+++ b/cur/programming/2-complexity/unit-2-vocab.es.html
@@ -13,18 +13,18 @@
 <h2>Unidad 2: Abstracción</h2>
 <h3>Laboratorio 1: Juegos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box12"><b>Laboratorio 1, página 1</b></a>: <strong>Variable</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 1</b></a>: <strong>Variable</strong>
 			<div class="ap-standard">AAP-1.A.1</div>
 			<p>Una <strong>variable</strong> es como un cuadro que puede contener un valor a cada vez, como una palabra, un disfraz o una lista (que puede contener muchas cosas). Puedes mirar lo que hay dentro las veces que quieras.</p>
 			<div class="endnote">En <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.es.html?topic=nyc_bjc%2F1-intro-loops.es.topic&course=bjc4nyc.es.html&novideo&noassignment" title="Unidad 1 Laboratorio 2 Página 2: Hacer que los programas hablen">Unidad 1 Laboratorio 2 Página 2: Hacer que los programas hablen</a>, aprendiste sobre <em>abstracción de procedimientos:</em> dar nombres a los programas colocándolos en nuevos bloques. Aquí, estamos comenzando a observar la <em>abstracción de datos</em>, dando nombres a números, texto, listas, etc. Cuando le das un nombre a algo, puedes referirte a él sin saber exactamente cuál es el valor.</div>
 
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box13"><b>Laboratorio 1, página 1</b></a>: <strong>Variable local</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 1</b></a>: <strong>Variable local</strong>
 			<p>Una <strong>variable local</strong> se puede configurar o usar solo en el entorno en el que se define. Este término incluye entradas a procedimientos y variables creadas por el bloque <code>para</code> o <code>variables de programa</code>.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box14"><b>Laboratorio 1, página 2</b></a>: <strong>Predicado</strong> y <strong> valor booleano</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 2</b></a>: <strong>Predicado</strong> y <strong> valor booleano</strong>
             <div class="sidenoteBig">
                 <a href="#hint-Boolean" data-bs-toggle="collapse" title="¿Cuál es el origen de la palabra &lt;em&gt;booleano&lt;/em&gt;?">
                     <img class="inline" src="/bjc-r/img/icons/read-more-mini.png" alt="Leer más" title="Leer más">
@@ -43,7 +43,7 @@
             <p>Los predicados reportan un <strong>valor booleano</strong> (<em>Boolean value</em>) (ya sea <img class="inline" src="/bjc-r/img/blocks/true.es.png" alt="verdadero" title="verdadero"> o <img class="inline" src="/bjc-r/img/blocks/false.es.png" alt="falso" title="falso">).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box15"><b>Laboratorio 1, página 2</b></a>: <strong>Condiciones</strong> y <strong>condicionales</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 2</b></a>: <strong>Condiciones</strong> y <strong>condicionales</strong>
             <p>Los bloques <code>si</code>(<em>if</em>) y <code>si / sino</code> (<em>if-else</em>) se denominan <strong>condicionales</strong> porque controlan el código en función de una <strong>condición</strong> verdadera o falsa.</p>
 			<div class="endnote">
                 <a href="#hint-predicates-examples" data-bs-toggle="collapse" title="Haz clic para ver ejemplos de predicados que se usan dentro de condicionales.">Haz clic para ver ejemplos de predicados que se usan dentro de condicionales.</a>
@@ -76,15 +76,15 @@ repetir hasta que (tocando (líder)?)
             </div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box16"><b>Laboratorio 1, página 4</b></a>: <strong>Variable global</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 4</b></a>: <strong>Variable global</strong>
             <p>Una <strong>variable global</strong> (<em>global variable</em>) es una variable que todos los scripts del programa pueden utilizar.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box17"><b>Laboratorio 1, página 4</b></a>: <strong>Inicialización</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 4</b></a>: <strong>Inicialización</strong>
                                 <p>Establecer el valor inicial de una variable se conoce como <strong>inicializar</strong><a name="inicializar" class="anchor"> </a>la variable.</p>
                             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box18"><b>Laboratorio 1, página 5</b></a>: <strong>Índice</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 5</b></a>: <strong>Índice</strong>
             <p>
                 El número de posición se denomina <strong>índice</strong> (<em>index</em>) del elemento en la lista. <br>
                 <img class="indent" src="/bjc-r/img/3-lists/item-2-of-list-reporting.es.png" alt="elemento (2) de (lista (manzana) (cantalupo) (plátano)) con una burbuja de texto que dice 'cantalupo'" title="elemento (2) de (lista (manzana) (cantalupo) (plátano)) con una burbuja de texto que dice 'cantalupo'"><br>
@@ -95,17 +95,17 @@ repetir hasta que (tocando (líder)?)
         </div>
 <h3>Laboratorio 2: Elaboración de listas</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box19"><b>Laboratorio 2, página 1</b></a>: <strong>Elemento</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 1</b></a>: <strong>Elemento</strong>
                 <div class="commentBig">AAP-1.C.2</div>
                 <p>Un <strong>elemento</strong> (<em>element</em>) es otro nombre para un artículo de una lista. (Si el mismo valor está en la lista dos veces, entonces contará como dos elementos diferentes). Cada elemento tiene un <em>índice</em> (posición) único en la lista. </p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box20"><b>Laboratorio 2, página 2</b></a>: <strong>Sublista</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 2</b></a>: <strong>Sublista</strong>
                 <p>Una <strong>sublista</strong> (<em>sublist</em>) es una lista que se utiliza como elemento de otra lista.</p>
 				<p>(La palabra sublista también se usa para referirse a algún subconjunto de una lista).</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box21"><b>Laboratorio 2, página 2</b></a>: <strong>Tipos de datos</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 2</b></a>: <strong>Tipos de datos</strong>
             <ul>
                 <li>
                     Un <strong>tipo de datos</strong> (<em>data type</em>) es la variedad de dato a la que algo pertenece (número, cadena de texto, lista, etc.). Por ejemplo, <em>número</em> es el tipo de datos para la primera entrada a <img src="/bjc-r/img/blocks/item.es.png" alt="elemento (1) de ()" title="elemento (1) de ()"> y <em>lista</em> es el tipo de dato para su segunda entrada.
@@ -120,7 +120,7 @@ repetir hasta que (tocando (líder)?)
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box22"><b>Laboratorio 2, página 2</b></a>: <strong>Tipos de datos abstractos (ADT)</strong> y <strong>abstracción de datos</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 2, página 2</b></a>: <strong>Tipos de datos abstractos (ADT)</strong> y <strong>abstracción de datos</strong>
             <ul>
                 <li>
                     <div class="ap-standard">AAP.1.D.1</div>
@@ -148,7 +148,7 @@ repetir hasta que (tocando (líder)?)
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box23"><b>Laboratorio 2, página 2</b></a>: <strong>Tabla</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-4"><b>Laboratorio 2, página 2</b></a>: <strong>Tabla</strong>
                             <p>Una <strong>tabla</strong> (<em>table</em>) es una estructura de datos bidimensional
                                  con filas y columnas. Si conoces un programa de <em>hojas de cálculo</em>, lo que este muestra es una tabla.</p>
                             <p>En Snap<em>!</em>, una tabla se implementa como
@@ -156,35 +156,35 @@ repetir hasta que (tocando (líder)?)
                                 fila de la tabla.</p>
 						</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box24"><b>Laboratorio 2, página 3</b></a>: <strong>Composición de funciones</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 3</b></a>: <strong>Composición de funciones</strong>
                 <p>Utilizar el resultado de <code>elemento</code> como entrada para <code>dirección de contacto</code> se denomina <strong>composición</strong> (<em>composition</em>) de funciones.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box25"><b>Laboratorio 2, página 3</b></a>: <strong>Recorrer una lista</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 3</b></a>: <strong>Recorrer una lista</strong>
             <div class="ap-standard">AAP-2.O.2</div>
             <p><strong>Recorrer</strong> (<em>traversing</em>) una lista significa mirar cada elemento de la lista. <code>Para cada</code> es iterativo. Es decir, es repetitivo, como <code>para</code>, que también puede atravesar una lista. Pero a diferencia de <code>para</code>, <code>para cada</code> recorre la lista <em>sin usar números de índice</em>.</p>
         </div>
 <h3>Laboratorio 3: Tomar decisiones</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box26"><b>Laboratorio 3, página 1</b></a>: <strong>Tipo de entrada</strong>, <strong>tipo de salida</strong>, <strong>dominio</strong> y <strong>rango</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 1</b></a>: <strong>Tipo de entrada</strong>, <strong>tipo de salida</strong>, <strong>dominio</strong> y <strong>rango</strong>
                     <ul>
                         <li>El <strong>tipo de entrada</strong> (<em>input type</em>) (normalmente llamado <strong>dominio</strong> [<em>domain</em>] entre los programadores) de una función es el tipo de datos que acepta como entrada.</li>
                         <li>El <strong>tipo de salida</strong> (<em>output type</em>) (normalmente llamado <strong>rango</strong> [<em>range</em>]) de una función es el tipo de datos que genera al final.</li>
                     </ul>
                 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box27"><b>Laboratorio 3, página 1</b></a>: <strong>Secuenciación</strong>, <strong>selección</strong> e <strong>iteración</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 3, página 1</b></a>: <strong>Secuenciación</strong>, <strong>selección</strong> e <strong>iteración</strong>
             <div class="ap-standard">Selección: AAP-2.G.1; secuenciación, selección, iteración: AAP-2.A.4</div>
             <p><strong>Selección</strong> decide (selecciona) qué parte de un algoritmo ejecutar basado en si una condición es verdadera o falsa.</p>
             <p>Cada algoritmo se puede construir usando <strong>secuenciación</strong> (siguiendo los pasos en orden), <strong>selección</strong> (decidir) e <strong>iteración</strong> (repetir).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box28"><b>Laboratorio 3, página 3</b></a>: <strong>Condicional anidada</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 3</b></a>: <strong>Condicional anidada</strong>
             <div class="ap-standard">AAP-2.I.1</div>
             <p>Una <strong>sentencia condicional anidada</strong> (<em>nested conditional statement</em>) es una sentencia <code>si</code> o <code>si / sino</code> dentro de otra sentencia <code>si / sino</code>.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box29"><b>Laboratorio 3, página 5</b></a>: <strong>Cadena</strong> e <strong>índice</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 5</b></a>: <strong>Cadena</strong> e <strong>índice</strong>
             <ul>
                 <li>
                     <div class="ap-standard">AAP-1.C.4</div>
@@ -198,12 +198,12 @@ repetir hasta que (tocando (líder)?)
         </div>
 <h3>Laboratorio 4: Matemáticas con computadoras</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box30"><b>Laboratorio 4, página 2</b></a>: <strong>Biblioteca de software</strong>
+<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 2</b></a>: <strong>Biblioteca de software</strong>
             <div class="commentBig">AAP-3.D.1</div>
             <p>Una <strong>biblioteca de software</strong> (<em>software library</em>) es una colección de procedimientos que se pueden usar en programas.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box31"><b>Laboratorio 4, página 2</b></a>: <strong>Interfaz de programa de aplicación (API)</strong>
+<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 4, página 2</b></a>: <strong>Interfaz de programa de aplicación (API)</strong>
             <div class="ap-standard">AAP-3.D.4, AAP-3.D.5</div>
             <p>Una <strong>interfaz de programa de aplicación</strong> (<em>application program interface</em> o API, por sus siglas en inglés) documenta lo que un programador necesita saber sobre el uso de la biblioteca: es una descripción del propósito, las entradas y las salidas de cada procedimiento (pero no sus algoritmos).</p>
             <div class="endnote">
@@ -224,7 +224,7 @@ repetir hasta que (tocando (líder)?)
 		</div>
 <h3>Laboratorio 5: Derechos de autor</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box32"><b>Laboratorio 5, página 2</b></a>: <strong>Creative Commons</strong>
+<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 5, página 2</b></a>: <strong>Creative Commons</strong>
                         <div class="ap-standard">IOC-1.F.5</div>
                         <ul>
                             <li>
@@ -232,7 +232,7 @@ repetir hasta que (tocando (líder)?)
                         </ul>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html" id="box33"><b>Laboratorio 5, página 2</b></a>: <strong>Software libre</strong>, <strong>código abierto</strong> y <strong>acceso abierto</strong>
+<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 5, página 2</b></a>: <strong>Software libre</strong>, <strong>código abierto</strong> y <strong>acceso abierto</strong>
                         <div class="ap-standard">IOC-1.F.5</div>
                         <p>
                             Se utilizan ideas similares a Creative Commons para diferentes tipos de material:

--- a/cur/programming/2-complexity/unit-2-vocab.html
+++ b/cur/programming/2-complexity/unit-2-vocab.html
@@ -13,17 +13,17 @@
 <h2>Unit 2: Abstraction</h2>
 <h3>Lab 1: Games</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box12"><b>Lab 1, Page 1</b></a>: <strong>Variable</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Variable</strong>
             <div class="ap-standard">AAP-1.A.1</div>
             <p>A <strong>variable</strong> is like a labeled box that can hold one value at a time, such as one word, one costume, or one list (which can contain many things). You can look at what's inside as many times as you want.</p>
             <div class="endnote">On <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.html?topic=nyc_bjc%2F1-intro-loops.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 1 Lab 2 Page 2: Making Programs Talk">Unit 1 Lab 2 Page 2: Making Programs Talk</a>, you learned about <em>procedural abstraction:</em> giving scripts names by putting them in new blocks. Here, we are starting to look at <em>data abstraction</em>, giving names to numbers, text, lists, etc. When you give something a name, you can refer to it without knowing exactly what the value is.</div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box13"><b>Lab 1, Page 1</b></a>: <strong>Local Variable</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/1-number-guessing-game.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 1</b></a>: <strong>Local Variable</strong>
 			<p>A <strong>local variable</strong> can be set or used only in the environment in which it is defined. This term includes inputs to procedures and variables created by the <code>for</code> or <code>script variables</code> block.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box14"><b>Lab 1, Page 2</b></a>: <strong>Predicate</strong> and <strong>Boolean value</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 2</b></a>: <strong>Predicate</strong> and <strong>Boolean value</strong>
             <div class="sidenoteBig">
                 <a href="#hint-Boolean" data-bs-toggle="collapse" title="Why is Boolean capitalized?">
                     <img class="inline" src="/bjc-r/img/icons/read-more-mini.png" alt="Read More" title="Read More">
@@ -42,7 +42,7 @@
             <p>Predicates report a <strong>Boolean value</strong> (either <img class="inline" src="/bjc-r/img/blocks/true.png" alt="true" title="true"> or <img class="inline" src="/bjc-r/img/blocks/false.png" alt="false" title="false">).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box15"><b>Lab 1, Page 2</b></a>: <strong>Conditions</strong> and <strong>Conditionals</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 2</b></a>: <strong>Conditions</strong> and <strong>Conditionals</strong>
             <p>The <code>if</code> and <code>if-else</code> blocks are called <strong>conditionals</strong> because they control the code based on a true-or-false <strong>condition</strong>.</p>
             <div class="todo">redo pic in yellowbox with plain prototype labels --MF, 2/6/25</div>
 			<div class="endnote">
@@ -76,15 +76,15 @@ repeat until (touching (Leader)?)
             </div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box16"><b>Lab 1, Page 4</b></a>: <strong>Global Variable</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 4</b></a>: <strong>Global Variable</strong>
             <p>A <strong>global variable</strong> is a variable that is usable by all scripts in the program.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box17"><b>Lab 1, Page 4</b></a>: <strong>Initialization</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/4-keeping-score.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 4</b></a>: <strong>Initialization</strong>
                                 <p>Setting the starting value of a variable is known as <strong>initializing</strong><a name="initialize" class="anchor"> </a>the variable.</p>
                             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box18"><b>Lab 1, Page 5</b></a>: <strong>Index</strong>
+<a href="/bjc-r/cur/programming/2-complexity/1-variables-games/5-choosing-avatar.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 5</b></a>: <strong>Index</strong>
             <p>
                 The position number is called the <strong>index</strong> of the item in the list.  <br>
                 <img class="indent" src="/bjc-r/img/3-lists/item-2-of-list-reporting.png" alt="item (2) of (list (apple) (cantaloupe) (banana)) reporting 'cantaloupe'" title="item (2) of (list (apple) (cantaloupe) (banana)) reporting 'cantaloupe'"><br>
@@ -95,17 +95,17 @@ repeat until (touching (Leader)?)
         </div>
 <h3>Lab 2: Making Lists</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box19"><b>Lab 2, Page 1</b></a>: <strong>Element</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/1-shopping-list-app.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Element</strong>
                 <div class="commentBig">AAP-1.C.2</div>
                 <p>An <strong>element</strong> is another name for an item in a list. (If the same value is in the list twice, that counts as two different elements.) Each element has a unique <em>index</em> (position) in the list. </p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box20"><b>Lab 2, Page 2</b></a>: <strong>Sublist</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 2</b></a>: <strong>Sublist</strong>
                 <p>A <strong>sublist</strong> is a list used as an item of another list.</p>
 				<p>(The word sublist is also used to refer to some subset of a list.)</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box21"><b>Lab 2, Page 2</b></a>: <strong>Data Type</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 2</b></a>: <strong>Data Type</strong>
             <ul>
                 <li>
                     A <strong>data type</strong> is what kind of data something is (number, text string, list, etc.). For example, <em>number</em> is the data type for the first input to <img src="/bjc-r/img/blocks/item.png" alt="item (1) of ()" title="item (1) of ()"> and <em>list</em> is the the data type for its second input.
@@ -120,7 +120,7 @@ repeat until (touching (Leader)?)
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box22"><b>Lab 2, Page 2</b></a>: <strong>Abstract Data Type (ADT)</strong> and <strong>Data Abstraction</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-3"><b>Lab 2, Page 2</b></a>: <strong>Abstract Data Type (ADT)</strong> and <strong>Data Abstraction</strong>
             <ul>
                 <li>
                     <div class="ap-standard">AAP.1.D.1</div>
@@ -148,7 +148,7 @@ repeat until (touching (Leader)?)
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box23"><b>Lab 2, Page 2</b></a>: <strong>Table</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-4"><b>Lab 2, Page 2</b></a>: <strong>Table</strong>
 						<p>A <strong>table</strong> is a two-dimensional
 						data structure with rows and columns.  If you've
 						used a <em>spreadsheet</em> program, what it
@@ -158,35 +158,35 @@ repeat until (touching (Leader)?)
 						row of the table.</p>
 						</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box24"><b>Lab 2, Page 3</b></a>: <strong>Function Composition</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 3</b></a>: <strong>Function Composition</strong>
                 <p>Using the result from <code>item</code> as the input to <code>address from contact</code> is called <strong>composition</strong> of functions.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box25"><b>Lab 2, Page 3</b></a>: <strong>Traversing a List</strong>
+<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/3-traversing-list.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 3</b></a>: <strong>Traversing a List</strong>
             <div class="ap-standard">AAP-2.O.2</div>
             <p><strong>Traversing</strong> a list means looking at each item of the list. <code>For each</code> is iterative. That is, it's repetitive, like <code>for</code>, which can also traverse a list. But unlike <code>for</code>, <code>for each</code> traverses the list <em>without using index numbers</em>.</p>
         </div>
 <h3>Lab 3: Making Decisions</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box26"><b>Lab 3, Page 1</b></a>: <strong>Input Type</strong>, <strong>Output Type</strong>, <strong>Domain</strong>, and <strong>Range</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Input Type</strong>, <strong>Output Type</strong>, <strong>Domain</strong>, and <strong>Range</strong>
                     <ul>
                         <li>The <strong>input type</strong> (often called <strong>domain</strong> by programmers) of a function is the type of data that it accepts as input.</li>
                         <li>The <strong>output type</strong> (often called <strong>range</strong>) of a function is the type of data that it reports as output.</li>
                     </ul>
                 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box27"><b>Lab 3, Page 1</b></a>: <strong>Sequencing</strong>, <strong>Selection</strong>, and <strong>Iteration</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/1-what-is-predicate.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 3, Page 1</b></a>: <strong>Sequencing</strong>, <strong>Selection</strong>, and <strong>Iteration</strong>
             <div class="ap-standard">Selection: AAP-2.G.1; sequencing, selection, iteration: AAP-2.A.4</div>
             <p><strong>Selection</strong> means deciding (selecting) which part of an algorithm to run based on whether a condition is true or false.</p>
             <p>Every algorithm can be constructed using <strong>sequencing</strong> (following steps in order), <strong>selection</strong> (deciding), and <strong>iteration</strong> (repeating).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box28"><b>Lab 3, Page 3</b></a>: <strong>Nested Conditional</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/3-combining-conditionals.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 3</b></a>: <strong>Nested Conditional</strong>
             <div class="ap-standard">AAP-2.I.1</div>
             <p>A <strong>nested conditional statement</strong> is an <code>if</code> or <code>if else</code> statement inside another <code>if else</code> statement.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box29"><b>Lab 3, Page 5</b></a>: <strong>String</strong> and <strong>Index</strong>
+<a href="/bjc-r/cur/programming/2-complexity/3-predicates/5-keeping-list-items.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 5</b></a>: <strong>String</strong> and <strong>Index</strong>
             <ul>
                 <li>
                     <div class="ap-standard">AAP-1.C.4</div>
@@ -200,12 +200,12 @@ repeat until (touching (Leader)?)
         </div>
 <h3>Lab 4: Making Computers Do Math</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box30"><b>Lab 4, Page 2</b></a>: <strong>Software Library</strong>
+<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 2</b></a>: <strong>Software Library</strong>
             <div class="commentBig">AAP-3.D.1</div>
             <p>A <strong>software library</strong> is a collection of procedures that can be used in  programs.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box31"><b>Lab 4, Page 2</b></a>: <strong>Application Program Interface (API)</strong>
+<a href="/bjc-r/cur/programming/2-complexity/4-making-computers-do-math/2-math-predicates.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 4, Page 2</b></a>: <strong>Application Program Interface (API)</strong>
             <div class="ap-standard">AAP-3.D.4, AAP-3.D.5</div>
             <p>An <strong>application program interface (API)</strong> documents what a programmer needs to know about using a library: it's a description of each procedure's purpose, inputs, and outputs (but not its algorithms).</p>
             <div class="endnote">
@@ -226,7 +226,7 @@ repeat until (touching (Leader)?)
 		</div>
 <h3>Lab 5: Copyrights</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box32"><b>Lab 5, Page 2</b></a>: <strong>Creative Commons</strong>
+<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-1"><b>Lab 5, Page 2</b></a>: <strong>Creative Commons</strong>
                         <div class="ap-standard">IOC-1.F.5</div>
                         <ul>
                             <li>
@@ -234,7 +234,7 @@ repeat until (touching (Leader)?)
                         </ul>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html" id="box33"><b>Lab 5, Page 2</b></a>: <strong>Free Software</strong>, <strong>Open Source</strong>, and <strong>Open Access</strong>
+<a href="/bjc-r/cur/programming/2-complexity/5-copyrights/2-fairuse.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html#vocab-2"><b>Lab 5, Page 2</b></a>: <strong>Free Software</strong>, <strong>Open Source</strong>, and <strong>Open Access</strong>
                         <div class="ap-standard">IOC-1.F.5</div>
                         <p>
                             Ideas similar to Creative Commons are used for particular kinds of material:

--- a/cur/programming/3-lists/unit-3-exam-reference.es.html
+++ b/cur/programming/3-lists/unit-3-exam-reference.es.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Laboratorio 1: Lidiar con la complejidad</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/1-robot-in-a-maze.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box67"><strong>laboratorio 1, página 1</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/1-robot-in-a-maze.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 1</strong></a>
 			<p>
 				Hay problemas con un robot en una cuadrícula con procedimientos especiales que no existen en Snap<em>!</em>:
 				</p>

--- a/cur/programming/3-lists/unit-3-exam-reference.html
+++ b/cur/programming/3-lists/unit-3-exam-reference.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Lab 1: Dealing with Complexity</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/1-robot-in-a-maze.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box66"><strong>Lab 1, Page 1</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/1-robot-in-a-maze.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 1</strong></a>
 			<p>
 				There are problems about a robot in a grid with special procedures that don't exist in Snap<em>!</em>:
 				</p>

--- a/cur/programming/3-lists/unit-3-self-check.es.html
+++ b/cur/programming/3-lists/unit-3-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Lidiar con la complejidad</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Demonstrate the benefit of using parameters?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_1_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box68"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -49,7 +49,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Procedural abstraction of calculate_tax?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_1_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box69"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -86,7 +86,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Compare two snippets of code" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_3_1_4" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box70"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -134,7 +134,7 @@ DISPLAY(área) </pre>
                     </div><h2>Laboratorio 2: Lista de contactos</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Why are ADTs used in programming?" hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_3_2_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box71"><strong>laboratorio 2, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -170,7 +170,7 @@ DISPLAY(área) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Temperature flowchart inputs and outputs" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_2_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box72"><strong>laboratorio 2, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -215,7 +215,7 @@ DISPLAY(área) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mapLetterVsItem" hasinlinefeedback="true" maxchoices="1" responseidentifier="resp1_3_2_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box73"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -249,7 +249,7 @@ DISPLAY(área) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mapLetterVsItem" hasinlinefeedback="true" maxchoices="5" responseidentifier="resp2_3_2_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box74"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -303,7 +303,7 @@ DISPLAY(área) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="squares_mapkeepcombine" hasinlinefeedback="true" maxchoices="8" responseidentifier="resp1_3_2_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#box75"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/3-lists/unit-3-self-check.html
+++ b/cur/programming/3-lists/unit-3-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Dealing with Complexity</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Demonstrate the benefit of using parameters?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_1_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box67"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -49,7 +49,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Procedural abstraction of calculate_tax?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_1_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box68"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -86,7 +86,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Compare two snippets of code" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_3_1_4" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box69"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -134,7 +134,7 @@ DISPLAY(area) </pre>
                     </div><h2>Lab 2: Contact List</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Why are ADTs used in programming?" hasinlinefeedback="true" maxchoices="4" responseidentifier="ri1_3_2_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box70"><strong>Lab 2, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 1</strong></a>
 </div>
 
                         <div class="prompt">
@@ -170,7 +170,7 @@ DISPLAY(area) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Temperature flowchart inputs and outputs" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_3_2_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box71"><strong>Lab 2, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -215,7 +215,7 @@ DISPLAY(area) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mapLetterVsItem" hasinlinefeedback="true" maxchoices="1" responseidentifier="resp1_3_2_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box72"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -249,7 +249,7 @@ DISPLAY(area) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mapLetterVsItem" hasinlinefeedback="true" maxchoices="5" responseidentifier="resp2_3_2_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box73"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -303,7 +303,7 @@ DISPLAY(area) </pre>
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="squares_mapkeepcombine" hasinlinefeedback="true" maxchoices="8" responseidentifier="resp3_3_2_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#box74"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/3-lists/unit-3-vocab.es.html
+++ b/cur/programming/3-lists/unit-3-vocab.es.html
@@ -13,56 +13,56 @@
 <h2>Unidad 3: Estructuras de datos</h2>
 <h3>Laboratorio 1: Lidiar con la complejidad</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box34"><b>Laboratorio 1, página 3</b></a>: <strong>Recursión</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 3</b></a>: <strong>Recursión</strong>
             <p>Llamar a un procedimiento desde dentro de sí mismo se llama <strong>recursión</strong> (<em>recursion</em>) .</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box35"><b>Laboratorio 1, página 4</b></a>: <strong>Abstracción</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 4</b></a>: <strong>Abstracción</strong>
             <div class="ap-standard">AAP-3.B.1, AAP-3.B.5</div>
             <p>Como aprendiste en la <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.es.html?topic=nyc_bjc%2F1-intro-loops.es.topic&course=bjc4nyc.es.html&novideo&noassignment" title="Unidad 1, Laboratorio 2, Página 2: Hacer que los programas hablen">Unidad 1, Laboratorio 2, Página 2: Hacer que los programas hablen</a>, <strong>abstracción procesal</strong> (<em>procedural abstraction</em>) es el proceso de desarrollar un programa dividiendo un gran problema en subproblemas más pequeños.</p>
             <p>Crear un bloque <code>dibujar ladrillo</code> te permite pensar en términos de un procedimiento con un nombre relacionado con el problema que estás resolviendo. Esto hace que tu código sea más fácil de leer; una vez que hayas codificado y depurado el bloque, no necesitas pensar en cómo funciona cada vez que lo usas. Esa es la belleza de la abstracción procedimental.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box36"><b>Laboratorio 1, página 4</b></a>: <strong>Modularidad</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 4</b></a>: <strong>Modularidad</strong>
             <div class="ap-standard">AAP-3.B.2, AAP-3.B.3</div>
             <p><strong>Modularidad</strong> (<em>modularity</em>) es el proceso de romper un problema en pedazos más pequeños. La modularidad es una forma de abstracción procedimental.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/5-building-tic-tac-toe.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box37"><b>Laboratorio 1, página 5</b></a>: <strong>Clon</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/5-building-tic-tac-toe.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 5</b></a>: <strong>Clon</strong>
             <p>Un <strong>clon</strong> (<em>clone</em>) es una copia de un objeto que <em>comparte información</em> con su objeto padre (el objeto original). Por ejemplo, los clones tienen copias de cualquier secuencia de comandos del padre, y si se cambia la secuencia de comandos del padre, entonces las secuencias de comandos de los clones también cambian. Sin embargo, los cambios que realiza en un clon <em>no</em> se comparten con el padre, por lo que puede hacer cosas como mover cada clon a una posición diferente.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/6-debugging-recap.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box38"><b>Laboratorio 1, página 6</b></a>: <strong>Depuración</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/6-debugging-recap.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 6</b></a>: <strong>Depuración</strong>
         	<p>La <strong>depuración</strong> (<em>debugging</em>) es el arte de identificar errores en los programas informáticos y corregirlos.</p>
         </div>
 <h3>Laboratorio 2: Lista de contactos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box39"><b>Laboratorio 2, página 1</b></a>: <strong>Tipo de datos abstracto (ADT)</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 1</b></a>: <strong>Tipo de datos abstracto (ADT)</strong>
 			<p>Un <strong>tipo de datos abstracto</strong> (<em>abstract data type</em>, ADT por sus siglas en inglés) es un tipo de dato personalizado que tiene un significado específico para tu programa. Aprendiste sobre los tipos de datos y los TDA en<a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc%2F2-conditionals-abstraction.topic&course=bjc4nyc.html&novideo&noassignment" title="Unidad 2 Laboratorio 2 Página 2: Planificación de una aplicación de cuestionario">Unidad 2 Laboratorio 2 Página 2: Planificación de una aplicación de cuestionario</a>.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box40"><b>Laboratorio 2, página 2</b></a>: <strong>Entrada</strong> y <strong>salida</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 2</b></a>: <strong>Entrada</strong> y <strong>salida</strong>
                             <div class="ap-standard">CRD-2.C.1, CRD-2.C.4, CRD-2.C.6, CRD-2.D.1, CRD-2.D.2</div>
                             <p>Usamos "entrada" vagamente para referirnos a las casillas vacías en un bloque que se llenan con valores. Pero <strong>entrada</strong> (<em>input</em>) también se refiere a la información que ingresa el usuario en un programa, como en el bloque <code>preguntar y esperar</code>. La entrada del programa también puede provenir de tablas de datos, sonidos, imágenes, videos u otros programas.</p>
                             <p>Del mismo modo, <strong>salida</strong> (<em>output</em>) del programa significa cualquier dato enviado desde su programa al usuario o a cualquier dispositivo. Por lo general, la salida depende de la entrada.</p>
                         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/4-looking-up-data.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box41"><b>Laboratorio 2, página 4</b></a>: <strong>Modularidad</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/4-looking-up-data.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 4</b></a>: <strong>Modularidad</strong>
             <div class="ap-standard">AAP-3.B.2, AAP-3.B.3</div>
             <p><strong>Modularidad</strong> (<em>modularity</em>) es el proceso de dividir un proyecto de programación en subproblemas separados. Por ejemplo, en la página 2 de este laboratorio, creaste un código para agregar un contacto a tu aplicación y, en esta página, creaste un código para encontrar contactos.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box42"><b>Laboratorio 2, página 5</b></a>: <strong>Función de orden superior</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 5</b></a>: <strong>Función de orden superior</strong>
                 <p>Una <strong>función de orden superior</strong> (<em>higher-order function</em>) es una función que toma una función como entrada (o reporta una función como salida). </p>
             </div>
 <h3>Laboratorio 3: Tres en línea</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/3-tic-tac-toe/1-find-ties.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box43"><b>Laboratorio 3, página 1</b></a>: <strong>Variable del objeto</strong>
+<a href="/bjc-r/cur/programming/3-lists/3-tic-tac-toe/1-find-ties.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 1</b></a>: <strong>Variable del objeto</strong>
             <p>Una <strong>variable del objeto</strong> (<em>sprite variable</em>) es como una variable global en el sentido de que <em>no</em> pertenece a un <em>programa</em> en particular, pero sí pertenece a un <em>objeto en particular.</em></p>
         </div>
 <h3>Laboratorio 4: Robots e inteligencia artificial</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/4-robots-ai/1-what-is-ai.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html" id="box44"><b>Laboratorio 4, página 1</b></a>: <strong>La inteligencia artificial (IA)</strong>
+<a href="/bjc-r/cur/programming/3-lists/4-robots-ai/1-what-is-ai.es.html?topic=nyc_bjc/3-lists.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 1</b></a>: <strong>La inteligencia artificial (IA)</strong>
             <p><strong>La inteligencia artificial (IA)</strong> (<em>Artificial intelligence</em> o AI, por sus siglas en inglés) es un campo de la informática que se define vagamente como "intentar que las computadoras piensen".</p>
         </div>
 

--- a/cur/programming/3-lists/unit-3-vocab.html
+++ b/cur/programming/3-lists/unit-3-vocab.html
@@ -13,56 +13,56 @@
 <h2>Unit 3: Data Structures</h2>
 <h3>Lab 1: Dealing with Complexity</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box34"><b>Lab 1, Page 3</b></a>: <strong>Recursion</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 3</b></a>: <strong>Recursion</strong>
             <p>Calling a procedure from inside itself is called <strong>recursion</strong>.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box35"><b>Lab 1, Page 4</b></a>: <strong>Abstraction</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 4</b></a>: <strong>Abstraction</strong>
             <div class="ap-standard">AAP-3.B.1, AAP-3.B.5</div>
             <p>As you learned in <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/2-gossip.html?topic=nyc_bjc%2F1-intro-loops.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 1 Lab 2 Page 2: Making Programs Talk">Unit 1 Lab 2 Page 2: Making Programs Talk</a>, <strong>procedural abstraction</strong> is the process of developing a program by breaking up a large problem into smaller sub-problems.</p>
             <p>Creating a <code>draw brick</code> block lets you think in terms of a procedure with a name related to the problem you are solving. This makes your code easier to read, and once you've coded and debugged the block, you don't need to think about how it works each time you use it. That's the beauty of procedural abstraction.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box36"><b>Lab 1, Page 4</b></a>: <strong>Modularity</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/4-brick-wall.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 4</b></a>: <strong>Modularity</strong>
             <div class="ap-standard">AAP-3.B.2, AAP-3.B.3</div>
             <p><strong>Modularity</strong> is the process of breaking a problem into smaller pieces. Modularity is a form of procedural abstraction.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/5-building-tic-tac-toe.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box37"><b>Lab 1, Page 5</b></a>: <strong>Clone</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/5-building-tic-tac-toe.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 5</b></a>: <strong>Clone</strong>
             <p>A <strong>clone</strong> is a copy of a sprite that <em>shares information</em> with its parent sprite (the original sprite). For example, clones have copies of any scripts from the parent, and if the parent's script is changed, then the clones' scripts change too. However, changes you make to a clone are <em>not</em> shared with the parent, so you can do things like move each clone to a different position.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/1-abstraction/6-debugging-recap.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box38"><b>Lab 1, Page 6</b></a>: <strong>Debugging</strong>
+<a href="/bjc-r/cur/programming/3-lists/1-abstraction/6-debugging-recap.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 6</b></a>: <strong>Debugging</strong>
         	<p><strong>Debugging</strong> is the art of identifying errors in computer programs and fixing them.</p>
         </div>
 <h3>Lab 2: Contact List</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box39"><b>Lab 2, Page 1</b></a>: <strong>Abstract Data Type (ADT)</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/1-build-the-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Abstract Data Type (ADT)</strong>
 			<p>An <strong>abstract data type (ADT)</strong> is a custom data type that's meaningful to your program. You learned about data types and ADTs on <a href="/bjc-r/cur/programming/2-complexity/2-data-structures-art/2-quizzes.html?topic=nyc_bjc%2F2-conditionals-abstraction.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 2 Lab 2 Page 2: Planning a Quiz App">Unit 2 Lab 2 Page 2: Planning a Quiz App</a>.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box40"><b>Lab 2, Page 2</b></a>: <strong>Input</strong> and <strong>Output</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/2-adding-contact.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 2</b></a>: <strong>Input</strong> and <strong>Output</strong>
                             <div class="ap-standard">CRD-2.C.1, CRD-2.C.4, CRD-2.C.6, CRD-2.D.1, CRD-2.D.2</div>
                             <p>We use "input" loosely to mean the empty boxes in a block that get filled with values.  But <strong>input</strong> also means information entered into a program by the user, as in the <code>ask and wait</code> block.  Program input can also come from data tables, sounds, pictures, video, or other programs.</p>
                             <p>Similarly, program <strong>output</strong> means any data sent from your program to the user or to any device.  Typically, the output depends on the input.</p>
                         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/4-looking-up-data.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box41"><b>Lab 2, Page 4</b></a>: <strong>Modularity</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/4-looking-up-data.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 4</b></a>: <strong>Modularity</strong>
             <div class="ap-standard">AAP-3.B.2, AAP-3.B.3</div>
             <p><strong>Modularity</strong> is the process of breaking a programming project up into separate sub-problems. For example on page 2 of this lab, you built code to add a contact to your app, and on this page, you built code to find contacts.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box42"><b>Lab 2, Page 5</b></a>: <strong>Higher-Order Function</strong>
+<a href="/bjc-r/cur/programming/3-lists/2-contact-list/5-mapping-over-list.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 5</b></a>: <strong>Higher-Order Function</strong>
                 <p>A <strong>higher-order function</strong> is a function that takes a function as input (or reports a function as output). </p>
             </div>
 <h3>Lab 3: Tic-Tac-Toe</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/3-tic-tac-toe/1-find-ties.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box43"><b>Lab 3, Page 1</b></a>: <strong>Sprite Variable</strong>
+<a href="/bjc-r/cur/programming/3-lists/3-tic-tac-toe/1-find-ties.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Sprite Variable</strong>
             <p>A <strong>sprite variable</strong> is like a global variable in that it <em>doesn't</em> belong to a particular <em>script</em>, but it does belong to a particular <em>sprite.</em></p>
         </div>
 <h3>Lab 4: Robots and Artificial Intelligence</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/3-lists/4-robots-ai/1-what-is-ai.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html" id="box44"><b>Lab 4, Page 1</b></a>: <strong>Artificial Intelligence (AI)</strong>
+<a href="/bjc-r/cur/programming/3-lists/4-robots-ai/1-what-is-ai.html?topic=nyc_bjc/3-lists.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Artificial Intelligence (AI)</strong>
             <p>The field of computer science known as <strong>artificial intelligence (AI)</strong> is loosely defined as "trying to get computers to think."</p>
         </div>
 

--- a/cur/programming/4-internet/unit-4-self-check.es.html
+++ b/cur/programming/4-internet/unit-4-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Redes informáticas</h2>
 <div class="assessment-data" type="multiplechoice" identifier="cloud computing" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_1_1" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box76"><strong>laboratorio 1, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 1</strong></a>
 </div>
 
                         <div class="prompt">¿Cuál de las siguientes <em><strong>no</strong></em> es una ventaja de almacenar datos usando la <em>computación en la nube?</em>?</div>
@@ -38,7 +38,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the fewest number of nodes?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_1_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box77"><strong>laboratorio 1, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -79,7 +79,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the maximum that can fail?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_4_1_2" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box78"><strong>laboratorio 1, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -121,7 +121,7 @@
                     </div><h2>Laboratorio 2: Ciberseguridad</h2>
 <div class="assessment-data" type="multiplechoice" identifier="¿Cuáles de las siguientes son vulnerabilidades existentes de Internet, según los expertos?" hasinlinefeedback="true" maxchoices="3" responseidentifier="ri1_4_2_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box79"><strong>laboratorio 2, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 5</strong></a>
 </div>
 
                         <div class="prompt">¿Cuáles de las siguientes son vulnerabilidades existentes de Internet, según los expertos?</div>
@@ -145,7 +145,7 @@
                     </div><h2>Laboratorio 4: Representación y compresión de datos</h2>
 <div class="assessment-data" type="multiplechoice" identifier="¿Cuál de los siguientes NO se puede expresar usando un bit?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_1" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box80"><strong>laboratorio 4, página 1</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 1</strong></a>
 </div>
 
                         <div class="prompt">¿Cuál de los siguientes NO se puede expresar usando un bit?</div>
@@ -170,7 +170,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How many more items to identify with one extra bit?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box81"><strong>laboratorio 4, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 2</strong></a>
 </div>
 
                         <div class="prompt">Una empresa minorista en línea en particular utiliza secuencias binarias de 9 bits para identificar cada producto único para la venta. Con la esperanza de aumentar el número de productos que vende, la compañía planea cambiar a secuencias binarias de 10 bits. ¿Cuál de las siguientes afirmaciones describe mejor la consecuencia de usar secuencias de 10 bits en lugar de secuencias de 9 bits?</div>
@@ -195,7 +195,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which explains the 0?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_5" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box82"><strong>laboratorio 4, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 5</strong></a>
 </div>
 
                         <div class="prompt">Un programa en particular utiliza 4 bits para representar números enteros. Cuando ese programa suma los números 9 y 7, el resultado se da como 0. Identifica la mejor explicación del resultado.</div>
@@ -220,7 +220,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is NOT an explanation of low image quality?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_6" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box83"><strong>laboratorio 4, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 4, página 6</strong></a>
 </div>
 
                         <div class="prompt">Un estudiante de cine graba una película en su teléfono inteligente y luego guarda una copia en su computadora. Se da cuenta de que la copia guardada es de una calidad de imagen mucho menor que la original. ¿Cuál de los siguientes podría <strong>NO</strong> ser una posible explicación para la menor calidad de imagen?</div>
@@ -245,7 +245,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which are examples of lossless transformation?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri2_4_4_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box84"><strong>laboratorio 4, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 4, página 6</strong></a>
 </div>
 
                         <div class="prompt">Un artista visual está procesando una imagen digital. ¿Cuál de las siguientes opciones describe una transformación <strong>sin perdida</strong> de la que se puede recuperar la imagen original? <em>Elige dos respuestas.</em>
@@ -272,7 +272,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which are examples of lossless transformation?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri3_4_4_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#box85"><strong>laboratorio 4, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 4, página 6</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/4-internet/unit-4-self-check.html
+++ b/cur/programming/4-internet/unit-4-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Computer Networks</h2>
 <div class="assessment-data" type="multiplechoice" identifier="cloud computing" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_1_1" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box75"><strong>Lab 1, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 1</strong></a>
 </div>
 
                         <div class="prompt">Which of the following is <em><strong>not</strong></em> an advantage of storing data using <em>cloud computing</em>?</div>
@@ -38,7 +38,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the fewest number of nodes?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_1_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box76"><strong>Lab 1, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -80,7 +80,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the maximum that can fail?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_4_1_2" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box77"><strong>Lab 1, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -123,7 +123,7 @@
                     </div><h2>Lab 2: Cybersecurity</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which of the following are existing vulnerabilities of the Internet, according to experts?" hasinlinefeedback="true" maxchoices="3" responseidentifier="ri1_4_2_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box78"><strong>Lab 2, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 5</strong></a>
 </div>
 
                         <div class="prompt">Which of the following are existing vulnerabilities of the Internet, according to experts?</div>
@@ -147,7 +147,7 @@
                     </div><h2>Lab 4: Data Representation and Compression</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which cannot be represented by a bit?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_1" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box79"><strong>Lab 4, Page 1</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 1</strong></a>
 </div>
 
                         <div class="prompt">Which of the following CANNOT be expressed using one bit?</div>
@@ -172,7 +172,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How many more items to identify with one extra bit?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box80"><strong>Lab 4, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 2</strong></a>
 </div>
 
                         <div class="prompt">A particular online retail company uses 9-bit binary sequences to identify each unique product for sale. Expecting to increase the number of products it sells, the company is planning to switch to 10-bit binary sequences. Which of the statements below best describes the consequence of using 10-bit sequences instead of 9-bit sequences?</div>
@@ -197,7 +197,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which explains the 0?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_5" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box81"><strong>Lab 4, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 5</strong></a>
 </div>
 
                         <div class="prompt">A particular program uses 4 bits to represent whole numbers. When that program adds the numbers 9 and 7, the result is given as 0. Identify the best explanation of the result.</div>
@@ -222,7 +222,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is NOT an explanation of low image quality?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_4_4_6" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box82"><strong>Lab 4, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 4, Page 6</strong></a>
 </div>
 
                         <div class="prompt">A film student records a movie on his smartphone and then saves a copy on his computer. He notices that the saved copy is of much lower image quality than the original. Which of the following could <strong>NOT</strong> be a possible explanation for the lower image quality?</div>
@@ -247,7 +247,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which are examples of lossless transformation?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri2_4_4_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box83"><strong>Lab 4, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 4, Page 6</strong></a>
 </div>
 
                         <div class="prompt">A visual artist is processing a digital image.  Which of the following describe a <strong>lossless</strong> transformation from which the original image can be recovered? <em>Choose two answers.</em>
@@ -274,7 +274,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which are examples of lossless transformation?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri3_4_4_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#box84"><strong>Lab 4, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 4, Page 6</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/4-internet/unit-4-vocab.es.html
+++ b/cur/programming/4-internet/unit-4-vocab.es.html
@@ -13,7 +13,7 @@
 <h2>Unidad 4: ¿Cómo funciona Internet?</h2>
 <h3>Laboratorio 1: Redes informáticas</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box45"><b>Laboratorio 1, página 1</b></a>: <strong>La Internet</strong>, <strong>red informática</strong>, <strong>sistema informático</strong>, <strong>dispositivo informático</strong> y <strong>World Wide Web</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 1</b></a>: <strong>La Internet</strong>, <strong>red informática</strong>, <strong>sistema informático</strong>, <strong>dispositivo informático</strong> y <strong>World Wide Web</strong>
             <ul>
                 <li>
                     <strong>La Internet</strong> es una red informática que utiliza protocolos abiertos para estandarizar la comunicación. Se requiere un <em>dispositivo informático</em> conectado a un dispositivo conectado a Internet para acceder a Internet.
@@ -30,7 +30,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box46"><b>Laboratorio 1, página 1</b></a>: <strong>Enrutador</strong> y <strong>proveedores de servicios de Internet (ISP)</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 1</b></a>: <strong>Enrutador</strong> y <strong>proveedores de servicios de Internet (ISP)</strong>
             <ul>
                 <li>Un <strong>enrutador</strong> (<em>router</em>) es una computadora que pasa información de una red a otra.
                 <p>Tu computadora probablemente usa un enrutador que está en algún lugar de tu hogar para conectarse a tu proveedor de servicios de Internet.</p>
@@ -41,7 +41,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box47"><b>Laboratorio 1, página 1</b></a>: <strong>Ancho de banda</strong> y <strong>la nube</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 1, página 1</b></a>: <strong>Ancho de banda</strong> y <strong>la nube</strong>
             <ul>
                 <li>
 <div class="ap-standard">CSN-1.A.7, CSN-1.A.8</div>
@@ -50,7 +50,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box48"><b>Laboratorio 1, página 2</b></a>: <strong>Ruta</strong>, <strong>enrutamiento</strong>, <strong>escalabilidad</strong>, <strong>redundancia</strong> y <strong>tolerancia a fallas</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 2</b></a>: <strong>Ruta</strong>, <strong>enrutamiento</strong>, <strong>escalabilidad</strong>, <strong>redundancia</strong> y <strong>tolerancia a fallas</strong>
             <div class="ap-standard">CSN-1.A.5, CSN-1.A.6, CSN-1.B.6, CSN-1.E.2, CSN-1.E.5</div>
             <ul>
                 <li>Una <strong>ruta</strong> (<em>path</em>) es una secuencia de dispositivos informáticos conectados directamente que conectan un emisor con un receptor.</li>
@@ -61,7 +61,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box49"><b>Laboratorio 1, página 3</b></a>: <strong>Protocolo</strong>, <strong>dirección IP</strong>, <strong>paquete</strong> y <strong>conmutación de paquetes</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 3</b></a>: <strong>Protocolo</strong>, <strong>dirección IP</strong>, <strong>paquete</strong> y <strong>conmutación de paquetes</strong>
             <div class="ap-standard">CSN-1.B.3, CSN-1.C.1</div>
             <ul>
                 <li>Un <strong>protocolo</strong> (<em>protocol</em>) es un conjunto de reglas que especifican el comportamiento de un sistema.</li>
@@ -71,7 +71,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box50"><b>Laboratorio 1, página 3</b></a>: <strong>TCP/IP</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 3</b></a>: <strong>TCP/IP</strong>
             <p>
                 <strong>TCP/IP</strong> son un par de protocolos que proporcionan dos niveles de abstracción:
                 </p>
@@ -83,7 +83,7 @@
         </div>
 <h3>Laboratorio 2: Ciberseguridad</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box51"><b>Laboratorio 2, página 1</b></a>: <strong>Cifrado</strong> y <strong>descifrado</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 1</b></a>: <strong>Cifrado</strong> y <strong>descifrado</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <ul>
                 <li>
@@ -93,27 +93,27 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box52"><b>Laboratorio 2, página 1</b></a>: <strong>Cifrado simétrico</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 1</b></a>: <strong>Cifrado simétrico</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <p>Los cifrados de sustitución son ejemplos de <strong>cifrado simétrico</strong> (<em>symmetric decryption</em>) porque utilizan la <em>misma clave</em> tanto para el cifrado como para el descifrado.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box53"><b>Laboratorio 2, página 3</b></a>: <strong>Cifrado de clave pública</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 3</b></a>: <strong>Cifrado de clave pública</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <p>El <strong>cifrado de clave pública</strong> (<em>public key encryption</em>) utiliza un par de claves: una clave pública para el cifrado y una clave privada para el descifrado. El remitente usa la clave pública para cifrar el mensaje y el receptor usa su clave privada para descifrarlo.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box54"><b>Laboratorio 2, página 3</b></a>: <strong>SSL/TLS</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 3</b></a>: <strong>SSL/TLS</strong>
         	<p><strong>SSL/TLS</strong>, capa de conexión segura/seguridad de la capa de transporte, (<em>secure sockets layer/transport layer security</em>) es el estándar utilizado para la transferencia de información criptográficamente segura en Internet.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box55"><b>Laboratorio 2, página 3</b></a>: <strong>Las autoridades de certificación</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 2, página 3</b></a>: <strong>Las autoridades de certificación</strong>
         	<div class="ap-standard">IOC-2.B.6</div>
             <p><strong>Las autoridades de certificación</strong> (<em>Certificate authorities</em>) son organizaciones que emiten certificados digitales para verificar quién es el propietario de las claves de cifrado utilizadas para las comunicaciones seguras.</p>
             <p>En lugar de confiar en que el sitio web es quien dice ser, ahora debes confiar en que la Autoridad de certificación sea confiable.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box56"><b>Laboratorio 2, página 5</b></a>: <strong>Malware</strong>, <strong>software de registro de teclas</strong>, <strong>virus informático</strong>, <strong>software antivirus</strong> o <strong>antimalware</strong>, <strong>cortafuego</strong> y <strong>phishing</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 5</b></a>: <strong>Malware</strong>, <strong>software de registro de teclas</strong>, <strong>virus informático</strong>, <strong>software antivirus</strong> o <strong>antimalware</strong>, <strong>cortafuego</strong> y <strong>phishing</strong>
             <div class="ap-standard">malware: IOC-2.B.9, keylogging: IOC-2.C.2, virus: IOC-2.B.8, software antivirus o antimalware: IOC-2.B.7, phishing: IOC-2 .C .1</div>
             <ul>
                 <li>
@@ -126,21 +126,21 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box57"><b>Laboratorio 2, página 5</b></a>: <strong>Ataque DDoS</strong> o <strong>Denegación de Servicio Distribuida</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 2, página 5</b></a>: <strong>Ataque DDoS</strong> o <strong>Denegación de Servicio Distribuida</strong>
         	<p>Un <strong>ataque DDoS</strong> o <strong>Denegación de Servicio Distribuida</strong> (<em>Distributed Denial of Service attack</em>) usa un virus para inundar un servidor con muchas solicitudes de muchas computadoras a la vez para que a los usuarios de ese servidor se les niegue el servicio.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box58"><b>Laboratorio 2, página 5</b></a>: <strong>Punto de acceso no autorizado</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 2, página 5</b></a>: <strong>Punto de acceso no autorizado</strong>
 			<p>Un <strong>punto de acceso no autorizado</strong> (<em>rogue access point</em>)  es un punto de acceso inalámbrico que da acceso a una red segura sin la autorización del administrador de la red.</p>
 		</div>
 <h3>Laboratorio 3: Comunidad e interacciones en línea</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/5-computing-world.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box59"><b>Laboratorio 3, página 5</b></a>: <strong>Brecha digital</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/5-computing-world.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 5</b></a>: <strong>Brecha digital</strong>
                         <div class="ap-standard">IOC-1.C.1, IOC-1.C.2, IOC-1.C.3</div>
                         <p>La <strong>brecha digital</strong> (<em>digital divide</em>) se refiere al acceso desigual a las computadoras e Internet basado en la pobreza, el racismo, el sexismo, el aislamiento en el campo, la edad y otros factores. La brecha digital afecta tanto a las personas dentro de un país como a los propios países.</p>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box60"><b>Laboratorio 3, página 6</b></a>: <strong>Ciencia ciudadana</strong> y <strong>crowdsourcing</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 6</b></a>: <strong>Ciencia ciudadana</strong> y <strong>crowdsourcing</strong>
             <ul>
                 <li>
 <div class="ap-standard">IOC-1.E.3, IOC-1.E.4 (vocab box)</div>
@@ -150,7 +150,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box61"><b>Laboratorio 3, página 6</b></a>: <strong>Innovación informática</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 3, página 6</b></a>: <strong>Innovación informática</strong>
         <div class="ap-standard">CRD-1.A.1, CRD-1.A.2</div>
             <ul>
                 <li>Una <strong>innovación informática</strong> (<em>computing innovation</em>) puede ser física (como un automóvil autónomo), no física (como el software de edición de imágenes) o conceptual (como la idea de comercio electrónico), pero independientemente de la forma, debe incluir un programa como parte integral de su función.</li>
@@ -158,46 +158,46 @@
         </div>
 <h3>Laboratorio 4: Representación y compresión de datos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box62"><b>Laboratorio 4, página 1</b></a>: <strong>Bit</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 1</b></a>: <strong>Bit</strong>
             <div class="ap-standard">DAT-1.A.3</div>
             <p>Un <strong>bit</strong> es una sola unidad de datos que solo puede tener uno de dos valores. Normalmente representamos los dos valores como 0 (apagado) y 1 (encendido).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box63"><b>Laboratorio 4, página 1</b></a>: <strong>Byte</strong> y <strong>palabra</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 4, página 1</b></a>: <strong>Byte</strong> y <strong>palabra</strong>
             <div class="ap-standard">DAT-1.A.4</div>
             <p>Un <strong>byte</strong> tiene ocho bits.</p>
             <p>Una <strong>palabra</strong> (<em>word</em>) es una secuencia de cuántos bits procesa la CPU a la vez. A partir de 2017, las palabras son de 32 o 64 bits.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box64"><b>Laboratorio 4, página 2</b></a>: <strong>Secuencia binaria</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 2</b></a>: <strong>Secuencia binaria</strong>
             <p>Una <strong>secuencia binaria</strong> (<em>binary sequence</em>) (también se denomina <em>bitstream</em>) es una cadena de unos y ceros. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box65"><b>Laboratorio 4, página 2</b></a>: <strong>Analógicos</strong>, <strong>muestreo</strong> y <strong>frecuencia de muestreo</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 4, página 2</b></a>: <strong>Analógicos</strong>, <strong>muestreo</strong> y <strong>frecuencia de muestreo</strong>
             <p>Los datos <strong>analógicos</strong> (<em>analog</em>) tienen valores que cambian sin problemas, a diferencia de los datos digitales que cambian en intervalos discretos.</p>
             <p><strong>Muestreo</strong> (<em>sampling</em>) significa medir valores, llamados <strong>muestras</strong>, de una señal analógica a intervalos regulares.</p>
 			<p>La <strong>frecuencia de muestreo</strong> (<em>sampling rate</em>) es el número de muestras medidas por segundo.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/3-representing-numbers.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box66"><b>Laboratorio 4, página 3</b></a>: <strong>Ancho</strong> y <strong>palabra</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/3-representing-numbers.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 3</b></a>: <strong>Ancho</strong> y <strong>palabra</strong>
         	<p><strong>Ancho</strong> (<em>width</em>): el número de bits que procesa una CPU a la vez</p>
             <p><strong>Palabra</strong> (<em>word</em>): una secuencia binaria con esa cantidad de bits</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/4-floating-point.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box67"><b>Laboratorio 4, página 4</b></a>: <strong>Punto flotante</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/4-floating-point.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 4</b></a>: <strong>Punto flotante</strong>
             <p>La notación científica (como 2.350.000 = 2,35 × 10<sup>6</sup>) utiliza potencias de diez para representar valores muy grandes o muy pequeños. El <strong>punto flotante</strong> (o coma flotante) (<em>floating point</em>) es la misma idea pero con potencias de dos.</p>
 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box68"><b>Laboratorio 4, página 5</b></a>: <strong>Bit</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 5</b></a>: <strong>Bit</strong>
             <div class="ap-standard">DAT-1.A.3</div>
             <p>La palabra "bit" es una abreviatura de la expresión en inglés <em><strong>bi</strong>nary digi<strong>t</strong> (dígito binario).</em></p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box69"><b>Laboratorio 4, página 6</b></a>: <strong>Compresión sin pérdida</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 6</b></a>: <strong>Compresión sin pérdida</strong>
             <p>Los algoritmos de <strong>compresión de datos sin pérdida</strong> (<em>lossless data compression</em>) (como PNG) son reversibles (no hay pérdida de calidad); puedes reconstruir los datos originales. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html" id="box70"><b>Laboratorio 4, página 6</b></a>: <strong>Compresión con pérdida</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.es.html?topic=nyc_bjc/4-internet.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 4, página 6</b></a>: <strong>Compresión con pérdida</strong>
             <p>Los algoritmos de <strong>compresión de datos con pérdida</strong> (<em>lossy data compression</em>) <em>no</em> son totalmente reversibles; solo pueden reconstruir una <em>aproximación</em> de los datos originales.</p>
         </div>
 

--- a/cur/programming/4-internet/unit-4-vocab.html
+++ b/cur/programming/4-internet/unit-4-vocab.html
@@ -13,7 +13,7 @@
 <h2>Unit 4: How the Internet Works</h2>
 <h3>Lab 1: Computer Networks</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box45"><b>Lab 1, Page 1</b></a>: <strong>Internet</strong>, <strong>Computer Network</strong>, <strong>Computing System</strong>, <strong>Computing Device</strong>, and <strong>World Wide Web</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Internet</strong>, <strong>Computer Network</strong>, <strong>Computing System</strong>, <strong>Computing Device</strong>, and <strong>World Wide Web</strong>
             <ul>
                 <li>
                     The <strong>Internet</strong> is a <em>computer network</em> that uses open protocols to standardize communication. A <em>computing device</em> connected to an Internet-connected device is required to access the Internet.
@@ -29,7 +29,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box46"><b>Lab 1, Page 1</b></a>: <strong>Router</strong> and <strong>ISP</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 1</b></a>: <strong>Router</strong> and <strong>ISP</strong>
             <ul>
                 <li>A <strong>router</strong> is a computer that passes information from one network to another.
                 <p>Your computer probably uses a router that is somewhere in your home to connect to your <em>ISP</em>.</p>
@@ -41,7 +41,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box47"><b>Lab 1, Page 1</b></a>: <strong>Bandwidth</strong> and <strong>The Cloud</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-3"><b>Lab 1, Page 1</b></a>: <strong>Bandwidth</strong> and <strong>The Cloud</strong>
             <ul>
                 <li>
 <div class="commentBig">CSN-1.A.7, CSN-1.A.8</div>
@@ -50,7 +50,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box48"><b>Lab 1, Page 2</b></a>: <strong>Path</strong>, <strong>Routing</strong>, <strong>Scalability</strong>, <strong>Redundancy</strong>, and <strong>Fault tolerance</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 2</b></a>: <strong>Path</strong>, <strong>Routing</strong>, <strong>Scalability</strong>, <strong>Redundancy</strong>, and <strong>Fault tolerance</strong>
             <div class="ap-standard">CSN-1.A.5, CSN-1.A.6, CSN-1.B.6, CSN-1.E.2, CSN-1.E.5</div>
             <ul>
                 <li>A <strong>path</strong> is a sequence of directly connected computing devices that connect a sender to a receiver.</li>
@@ -65,7 +65,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box49"><b>Lab 1, Page 3</b></a>: <strong>Protocol</strong>, <strong>IP Address</strong>, <strong>Packet</strong>, and <strong>Packet Switching</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 3</b></a>: <strong>Protocol</strong>, <strong>IP Address</strong>, <strong>Packet</strong>, and <strong>Packet Switching</strong>
             <div class="ap-standard">CSN-1.B.3, CSN-1.C.1</div>
             <ul>
                 <li>A <strong>protocol</strong> is set of rules that specify the behavior of a system.</li>
@@ -76,7 +76,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box50"><b>Lab 1, Page 3</b></a>: <strong>TCP/IP</strong>
+<a href="/bjc-r/cur/programming/4-internet/1-reliable-communication/3-open-protocols.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 3</b></a>: <strong>TCP/IP</strong>
             <p>
                 <strong>TCP/IP</strong> is a pair of protocols that provide two levels of abstraction:
                 </p>
@@ -90,7 +90,7 @@
         </div>
 <h3>Lab 2: Cybersecurity</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box51"><b>Lab 2, Page 1</b></a>: <strong>Encryption</strong> and <strong>Decryption</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Encryption</strong> and <strong>Decryption</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <ul>
                 <li>
@@ -100,27 +100,27 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box52"><b>Lab 2, Page 1</b></a>: <strong>Symmetric Encryption</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/1-cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 1</b></a>: <strong>Symmetric Encryption</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <p>Substitution ciphers are examples of <strong>symmetric encryption</strong> because they use the <em>same key</em> for both encryption and decryption.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box53"><b>Lab 2, Page 3</b></a>: <strong>Public Key Encryption</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 3</b></a>: <strong>Public Key Encryption</strong>
             <div class="ap-standard">IOC-2.B.5</div>
             <p><strong>Public key encryption</strong> uses a pair of keys: a public key for encryption and a private key for decryption. The sender uses the public key to encrypt the message, and receiver uses their private key to decrypt it. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box54"><b>Lab 2, Page 3</b></a>: <strong>SSL/TLS</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 3</b></a>: <strong>SSL/TLS</strong>
         	<p><strong>SSL/TLS</strong> (secure sockets layer/transport layer security) is the standard used for cryptographically secured information transfer on the Internet.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box55"><b>Lab 2, Page 3</b></a>: <strong>Certificate Authorities</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/3-asymmetric_cryptography.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-3"><b>Lab 2, Page 3</b></a>: <strong>Certificate Authorities</strong>
         	<div class="ap-standard">IOC-2.B.6</div>
             <p><strong>Certificate authorities</strong> are organizations that issue digital certificates to verify who owns the encryption keys used for secured communications.</p>
             <p>Instead of trusting that the website is who they say they are, you now have to trust that the Certificate Authority is reliable.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box56"><b>Lab 2, Page 5</b></a>: <strong>Malware</strong>, <strong>Keylogging Software</strong>, <strong>Computer Virus</strong>, <strong>Antivirus</strong> or <strong>Anti-Malware Software</strong>, <strong>Firewall</strong>, and <strong>Phishing</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 5</b></a>: <strong>Malware</strong>, <strong>Keylogging Software</strong>, <strong>Computer Virus</strong>, <strong>Antivirus</strong> or <strong>Anti-Malware Software</strong>, <strong>Firewall</strong>, and <strong>Phishing</strong>
             <div class="ap-standard">malware: IOC-2.B.9, keylogging: IOC-2.C.2, virus: IOC-2.B.8, antivirus or anti-malware software: IOC-2.B.7, phishing: IOC-2.C.1</div>
             <ul>
                 <li>
@@ -136,21 +136,21 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box57"><b>Lab 2, Page 5</b></a>: <strong>DDoS (Distributed Denial of Service) attack</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 2, Page 5</b></a>: <strong>DDoS (Distributed Denial of Service) attack</strong>
         	<p>A <strong>DDoS (Distributed Denial of Service) attack</strong> uses a virus to flood a server with many requests from many computers at once so that users of that server are denied service.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box58"><b>Lab 2, Page 5</b></a>: <strong>Rogue Access Point</strong>
+<a href="/bjc-r/cur/programming/4-internet/2-cybersecurity/5-security-risks.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-3"><b>Lab 2, Page 5</b></a>: <strong>Rogue Access Point</strong>
 			<p>A <strong>rogue access point</strong> is a wireless access point that gives access to a secure network without the authorization of the network administrator.</p>
 		</div>
 <h3>Lab 3: Community and Online Interactions</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/5-computing-world.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box59"><b>Lab 3, Page 5</b></a>: <strong>Digital Divide</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/5-computing-world.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 5</b></a>: <strong>Digital Divide</strong>
                         <div class="ap-standard">IOC-1.C.1, IOC-1.C.2, IOC-1.C.3</div>
                         <p>The <strong>digital divide</strong> refers to unequal access to computers and the Internet based on poverty, racism, sexism, isolation in the countryside, age, and other factors. The digital divide affects both individuals within a country and countries themselves.</p>
                     </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box60"><b>Lab 3, Page 6</b></a>: <strong>Citizen Science</strong> and <strong>Crowdsourcing</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 6</b></a>: <strong>Citizen Science</strong> and <strong>Crowdsourcing</strong>
             <ul>
                 <li>
 <div class="ap-standard">IOC-1.E.3, IOC-1.E.4 (vocab box)</div>
@@ -160,7 +160,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box61"><b>Lab 3, Page 6</b></a>: <strong>Computing Innovation</strong>
+<a href="/bjc-r/cur/programming/4-internet/3-community/6-benefits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 3, Page 6</b></a>: <strong>Computing Innovation</strong>
         <div class="ap-standard">CRD-1.A.1, CRD-1.A.2</div>
             <ul>
                 <li>A <strong>computing innovation</strong> can be physical (such as a self-driving car), non-physical software (such as picture editing software), or conceptual (such as the idea of e-commerce), but regardless of the form, they must include a program as an integral part of their function.</li>
@@ -168,46 +168,46 @@
         </div>
 <h3>Lab 4: Data Representation and Compression</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box62"><b>Lab 4, Page 1</b></a>: <strong>Bit</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Bit</strong>
             <div class="ap-standard">DAT-1.A.3</div>
             <p>A <strong>bit</strong> is a single unit of data that can only have one of two values. We usually represent the two values as 0 (off) and 1 (on).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box63"><b>Lab 4, Page 1</b></a>: <strong>Byte</strong> and <strong>Word</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/1-bits.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 4, Page 1</b></a>: <strong>Byte</strong> and <strong>Word</strong>
             <div class="ap-standard">DAT-1.A.4</div>
             <p>A <strong>byte</strong> is eight bits.</p>
             <p>A <strong>word</strong> is a sequence of however many bits the CPU processes at a time. As of 2017, words are 32 or 64 bits.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box64"><b>Lab 4, Page 2</b></a>: <strong>Binary Sequence</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 2</b></a>: <strong>Binary Sequence</strong>
             <p>A <strong>binary sequence</strong> (also called a <em>bitstream</em>) is a string of ones and zeros. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box65"><b>Lab 4, Page 2</b></a>: <strong>Analog</strong>, <strong>Sampling</strong>, and <strong>Sampling Rate</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/2-sequences.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 4, Page 2</b></a>: <strong>Analog</strong>, <strong>Sampling</strong>, and <strong>Sampling Rate</strong>
             <p><strong>Analog</strong> data have values that change smoothly, unlike digital data which change in discrete intervals.</p>
             <p><strong>Sampling</strong> means measuring values, called <strong>samples</strong>, of an analog signal at regular intervals.</p>
 			<p>The <strong>sampling rate</strong> is the number of samples measured per second.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/3-representing-numbers.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box66"><b>Lab 4, Page 3</b></a>: <strong>Width</strong> and <strong>Word</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/3-representing-numbers.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 3</b></a>: <strong>Width</strong> and <strong>Word</strong>
         	<p><strong>width</strong>: the number of bits that a CPU processes at a time</p>
             <p><strong>word</strong>: a binary sequence of that many bits</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/4-floating-point.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box67"><b>Lab 4, Page 4</b></a>: <strong>Floating Point</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/4-floating-point.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 4</b></a>: <strong>Floating Point</strong>
             <p>Scientific notation (such as 2,350,000 = 2.35 × 10<sup>6</sup>) uses powers of ten to represent very large or very small values. <strong>Floating point</strong> is the same idea but with powers of two.</p>
 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box68"><b>Lab 4, Page 5</b></a>: <strong>Bit</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/5-binary.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 5</b></a>: <strong>Bit</strong>
             <div class="ap-standard">DAT-1.A.3</div>
             <p>The word "bit" is an abbreviation for <em><strong>bi</strong>nary digi<strong>t</strong>.</em></p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box69"><b>Lab 4, Page 6</b></a>: <strong>Lossless Compression</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 6</b></a>: <strong>Lossless Compression</strong>
             <p><strong>Lossless data compression</strong> algorithms (such as PNG) are reversible (there is no loss in quality); you can reconstruct the original data. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html" id="box70"><b>Lab 4, Page 6</b></a>: <strong>Lossy Compression</strong>
+<a href="/bjc-r/cur/programming/4-internet/4-representation-compression/6-compression.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html#vocab-2"><b>Lab 4, Page 6</b></a>: <strong>Lossy Compression</strong>
             <p><strong>Lossy data compression</strong> algorithms are <em>not</em> fully reversible; you can reconstruct only an <em>approximation</em> of the original data.</p>
         </div>
 

--- a/cur/programming/5-algorithms/unit-5-exam-reference.es.html
+++ b/cur/programming/5-algorithms/unit-5-exam-reference.es.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Laboratorio 1: Algoritmos de búsqueda y eficiencia</h2>
-<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box89"><strong>laboratorio 1, página 5</strong></a>
+<div class="exam summaryBox"> de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#exam-1"><strong>laboratorio 1, página 5</strong></a>
             <ul>
                 <li>
 <div class="ap-standard">AAP-4.A.7</div>

--- a/cur/programming/5-algorithms/unit-5-exam-reference.html
+++ b/cur/programming/5-algorithms/unit-5-exam-reference.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <h2>Lab 1: Search Algorithms and Efficiency</h2>
-<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box88"><strong>Lab 1, Page 5</strong></a>
+<div class="exam summaryBox"> from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#exam-1"><strong>Lab 1, Page 5</strong></a>
             <ul>
                 <li>
 <div class="ap-standard">AAP-4.A.7</div>

--- a/cur/programming/5-algorithms/unit-5-self-check.es.html
+++ b/cur/programming/5-algorithms/unit-5-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Algoritmos de búsqueda y eficiencia</h2>
 <div class="assessment-data" type="multiplechoice" identifier="In order to use a binary search, the data must be..." hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box86"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -43,7 +43,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which of the following questions can be answered with a binary search, assuming the data are sorted?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri2_5_1_3" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box87"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">¿Cuál de las siguientes preguntas se puede responder con una búsqueda binaria, suponiendo que los datos estén ordenados? Marca todas las que apliquen: </div>
@@ -76,7 +76,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Timing of database tasks" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_5" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box88"><strong>laboratorio 1, página 5</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -146,7 +146,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="In which of the following problems is a heuristic solution appropriate?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_1_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box90"><strong>laboratorio 1, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -181,7 +181,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How long will this sequential script take to run?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_8" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box91"><strong>laboratorio 1, página 8</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 8</strong></a>
 </div>
 
                         <div class="prompt">
@@ -210,7 +210,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How long will this parallel script take to run?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_1_8" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box92"><strong>laboratorio 1, página 8</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 8</strong></a>
 </div>
 
                   <div class="prompt">
@@ -249,7 +249,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the speedup for this parallel solution when compared to the sequential solution?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_5_1_8" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box93"><strong>laboratorio 1, página 8</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 1, página 8</strong></a>
 </div>
 
                         <div class="prompt">
@@ -295,7 +295,7 @@
                     </div><h2>Laboratorio 3: Transformar datos en información</h2>
 <div class="assessment-data" type="multiplechoice" identifier="migrating birds" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_3_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box94"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -329,7 +329,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="searching for patterns" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_3_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box95"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">Usando computadoras, los investigadores a menudo buscan grandes conjuntos de datos para encontrar patrones interesantes en los datos. ¿Cuál de los siguientes <em><strong>no</strong></em> es un ejemplo donde la búsqueda de patrones es necesaria para reunir la información deseada?</div>
@@ -354,7 +354,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="car hailing company trends" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_5_3_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box96"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -381,7 +381,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="information about song purchases" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_5_3_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box97"><strong>laboratorio 3, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-4"><strong>laboratorio 3, página 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -456,7 +456,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mobile phone recording metadata" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_3_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box98"><strong>laboratorio 3, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 3, página 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -490,7 +490,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="example of metadata" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_3_6" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#box99"><strong>laboratorio 3, página 6</strong></a>
+   de <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 3, página 6</strong></a>
 </div>
 
                         <div class="prompt">¿Cuál de los siguientes <em><strong>no</strong></em> es un ejemplo de <em>metadatos</em>?</div>

--- a/cur/programming/5-algorithms/unit-5-self-check.html
+++ b/cur/programming/5-algorithms/unit-5-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Search Algorithms and Efficiency</h2>
 <div class="assessment-data" type="multiplechoice" identifier="In order to use a binary search, the data must be..." hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box85"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -49,7 +49,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which of the following questions can be answered with a binary search, assuming the data are sorted?" hasinlinefeedback="true" maxchoices="2" responseidentifier="ri2_5_1_3" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box86"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -85,7 +85,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Timing of database tasks" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_5" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box87"><strong>Lab 1, Page 5</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 5</strong></a>
 </div>
 
                         <div class="prompt">
@@ -158,7 +158,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="In which of the following problems is a heuristic solution appropriate?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_1_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box89"><strong>Lab 1, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -193,7 +193,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How long will this sequential script take to run?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_1_8" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box90"><strong>Lab 1, Page 8</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 8</strong></a>
 </div>
 
                         <div class="prompt">
@@ -222,7 +222,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="How long will this parallel script take to run?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_1_8" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box91"><strong>Lab 1, Page 8</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 8</strong></a>
 </div>
 
                   <div class="prompt">
@@ -261,7 +261,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="What is the speedup for this parallel solution when compared to the sequential solution?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_5_1_8" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box92"><strong>Lab 1, Page 8</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 1, Page 8</strong></a>
 </div>
 
                         <div class="prompt">
@@ -307,7 +307,7 @@
                     </div><h2>Lab 3: Turning Data into Information</h2>
 <div class="assessment-data" type="multiplechoice" identifier="migrating birds" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_3_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box93"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -341,7 +341,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="searching for patterns" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_3_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box94"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">Using computers, researchers often search large data sets to find interesting patterns in the data.  Which is of the following is <em><strong>not</strong></em> an example where searching for patterns is needed to gather desired information?</div>
@@ -366,7 +366,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="car hailing company trends" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_5_3_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box95"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -393,7 +393,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="information about song purchases" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_5_3_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box96"><strong>Lab 3, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/2-self-check.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-4"><strong>Lab 3, Page 2</strong></a>
 </div>
 
                         <div class="prompt">
@@ -466,7 +466,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="mobile phone recording metadata" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_5_3_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box97"><strong>Lab 3, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 3, Page 6</strong></a>
 </div>
 
                         <div class="prompt">
@@ -499,7 +499,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="example of metadata" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_5_3_6" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#box98"><strong>Lab 3, Page 6</strong></a>
+   from <a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 3, Page 6</strong></a>
 </div>
 
                         <div class="prompt">Which of the following is <em><strong>not</strong></em> an example of <em>metadata</em>?</div>

--- a/cur/programming/5-algorithms/unit-5-vocab.es.html
+++ b/cur/programming/5-algorithms/unit-5-vocab.es.html
@@ -13,7 +13,7 @@
 <h2>Unidad 5: Algoritmos y Simulaciones</h2>
 <h3>Laboratorio 1: Algoritmos de búsqueda y eficiencia</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box71"><b>Laboratorio 1, página 2</b></a>: <strong>Problema</strong> vs. <strong>instancia de un problema</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 2</b></a>: <strong>Problema</strong> vs. <strong>instancia de un problema</strong>
 			<div class="ap-standard">AAP-4.A.1</div>
             <ul>
                 <li>Un <strong>problema</strong> (<em>problem</em>) es una descripción general de una tarea que puede (o no) ser resuelta algorítmicamente.</li>
@@ -21,7 +21,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box72"><b>Laboratorio 1, página 2</b></a>: <strong>Tiempo lineal</strong> vs. <strong>búsqueda lineal</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 2</b></a>: <strong>Tiempo lineal</strong> vs. <strong>búsqueda lineal</strong>
 			<ul>
                 <li>Un algoritmo toma <strong>tiempo lineal</strong> (<em>linear time</em>) si al multiplicar el tamaño de la entrada por diez se multiplica el tiempo requerido por diez.<br>
                 <img class="indent noshadow" style="height:300px" src="/bjc-r/img/5-algorithms/size-vs-time.es.png" alt="gráfico de tamaño contra tiempo mostrando una línea recta a través del origen y un punto situado arriba a la derecha, con coordenadas marcadas para x=10,000 y x=100,000" title="gráfico de tamaño contra tiempo mostrando una línea recta a través del origen y un punto situado arriba a la derecha, con coordenadas marcadas para x=10,000 y x=100,000 marcados">
@@ -32,7 +32,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box73"><b>Laboratorio 1, página 3</b></a>:<strong> Búsqueda binaria</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 3</b></a>:<strong> Búsqueda binaria</strong>
         	<div class="ap-standard">AAP-2.P.1, AAP-2.P.2</div>
             <p>Un algoritmo de <strong>búsqueda binaria</strong> (<em>binary search</em>) comienza en medio de una lista <em>ordenada</em> y elimina repetidamente la mitad de la lista hasta que se encuentra el valor deseado o se han eliminado todos los elementos.</p>
             <div class="ap-standard">AAP-2.O.1</div>
@@ -40,12 +40,12 @@
             <p>La búsqueda lineal hace un recorrido <em>completo</em> de la lista. La búsqueda binaria ahorra tiempo al hacer un recorrido <em>parcial</em> de la lista.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/4-efficiency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box74"><b>Laboratorio 1, página 4</b></a>: <strong>Eficiencia</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/4-efficiency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 4</b></a>: <strong>Eficiencia</strong>
             <div class="ap-standard">AAP-4.A.3</div>
             <p>La relación entre el tamaño de la entrada y el número de pasos requeridos para resolver un problema es la <strong>eficiencia</strong> (<em>efficiency</em>) del algoritmo utilizado para resolver el problema.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box75"><b>Laboratorio 1, página 5</b></a>: <strong>Tiempo lineal</strong>, <strong>tiempo sublineal</strong>, <strong>tiempo constante</strong> y <strong>tiempo cuadrático </strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 5</b></a>: <strong>Tiempo lineal</strong>, <strong>tiempo sublineal</strong>, <strong>tiempo constante</strong> y <strong>tiempo cuadrático </strong>
             <ul>
                 <li>Un algoritmo toma <strong>tiempo lineal</strong> (<em>linear time</em>) el número de pasos es proporcional al tamaño de la entrada; doblando el tamaño de la entrada se dobla el tiempo requerido.</li>
                 <li>Un algoritmo toma <strong>tiempo sublineal</strong> (<em>sublinear time</em>) si el tiempo aumenta más lentamente que el tamaño.</li>
@@ -54,7 +54,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box76"><b>Laboratorio 1, página 5</b></a>: <strong>Tiempo polinómico</strong> y <strong>tiempo exponencial</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 5</b></a>: <strong>Tiempo polinómico</strong> y <strong>tiempo exponencial</strong>
             <ul>
                 <li>
                     Un algoritmo toma <strong>tiempo polinómico</strong> si el número de pasos es menor o igual a una potencia del tamaño de la entrada, como la constante (<em>n</em><sup>0</sup>), sublineal, lineal (<em>n</em><sup>1</sup>), cuadrático (<em>n</em><sup>2</sup>), o cúbico (<em>n</em><sup>3</sup>).
@@ -65,7 +65,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box77"><b>Laboratorio 1, página 6</b></a>: <strong>Problema de decisión</strong> vs. <strong>problema de optimización </strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 6</b></a>: <strong>Problema de decisión</strong> vs. <strong>problema de optimización </strong>
           <div class="ap-standard">AAP-4.A.2</div>
             <ul>
                 <li>Un <strong>problema de decisión</strong> (<em>decision problem</em>) es un problema con una respuesta verdadera/falsa (por ejemplo, "¿es 5,825,496,221 un número primo?").</li>
@@ -73,13 +73,13 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box78"><b>Laboratorio 1, página 6</b></a>: <strong>Problema resoluble</strong> vs. <strong>problema indecidible</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 6</b></a>: <strong>Problema resoluble</strong> vs. <strong>problema indecidible</strong>
             <div class="ap-standard">AAP-4.B.1, AAP-4.B.2, AAP-4.B.3</div>
             <p>Un problema <strong>resoluble</strong> (<em>decidable</em>) es un problema de decisión para el cual es posible escribir un algoritmo que dará una salida correcta para todas las entradas. </p>
             <p>Un problema <strong>indecidible</strong> (<em>undecidable</em>) es lo opuesto.  <em>No </em>es posible escribir un algoritmo que dará una salida correcta para todas las entradas—aunque podría ser posible para algunos de ellos.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box79"><b>Laboratorio 1, página 8</b></a>: <strong>Computación secuencial</strong> vs. <strong>computación en paralelo</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 8</b></a>: <strong>Computación secuencial</strong> vs. <strong>computación en paralelo</strong>
 			<div class="ap-standard">CSN-2.A.1, CSN-2.A.2</div>
             <p>
 				Esta sección cubre dos modelos de computación:
@@ -91,18 +91,18 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box80"><b>Laboratorio 1, página 8</b></a>: <strong>Computación distribuida</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 8</b></a>: <strong>Computación distribuida</strong>
             <div class="ap-standard">CSN-2.A.3</div>
             <p><strong>Computación distribuida</strong> (<em>distributed computing</em>) es una forma de computación paralela que utiliza múltiples computadoras (tal vez incluso se extienda por todo el mundo).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box81"><b>Laboratorio 1, página 8</b></a>: <strong>Procesador</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 1, página 8</b></a>: <strong>Procesador</strong>
                 <p>Un <strong>procesador</strong> (<em>processor</em>) es una pieza de circuitos dentro de una computadora que procesa las instrucciones de los programas de computación.</p>
                 <p class="center"><img src="/bjc-r/img/6-computers/Hardware_img/CPU_small.jpg" alt="CPU" title="CPU"></p>
                 <p><small>Créditos de la imagen: Wikipedia usuario Solipsist</small></p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box82"><b>Laboratorio 1, página 8</b></a>: <strong>Aceleración</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-4"><b>Laboratorio 1, página 8</b></a>: <strong>Aceleración</strong>
             <div class="ap-standard">CSN-2.A.7</div>
             <p>
                 Los programadores se refieren a la <strong>aceleración</strong> (<em>speedup</em>) de la solución paralela para describir cuántas veces más rápido se compara la solución paralela con la solución secuencial:<br>
@@ -111,13 +111,13 @@
         </div>
 <h3>Laboratorio 2: Simulaciones</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/2-simulation/1-intro-to-simulations.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box83"><b>Laboratorio 2, página 1</b></a>: <strong>Simulaciones</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/2-simulation/1-intro-to-simulations.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 1</b></a>: <strong>Simulaciones</strong>
             <div class="ap-standard">AAP-3.F.1, AAP-3.F.2</div>
             <p>Las <strong>simulaciones</strong> (<em>simulations</em>) son representaciones por computadora de cosas o situaciones reales que varían con el tiempo. Una simulación es una abstracción diseñada para un propósito en particular.</p>
         </div>
 <h3>Laboratorio 3: Transformar datos en información</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box84"><b>Laboratorio 3, página 1</b></a>: <strong>Datos</strong> vs. <strong>información</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 1</b></a>: <strong>Datos</strong> vs. <strong>información</strong>
 			<div class="ap-standard">DAT-2.A.1</div>
             <ul>
                 <li>Los <strong>datos</strong> (<em>data</em>) son los valores que los ordenadores reciben de varias fuentes, incluyendo la actividad humana, los sensores, etc.</li>
@@ -126,7 +126,7 @@
 			<div class="ap-standard">DAT-2.A.2</div>Los datos proporcionan oportunidades para identificar tendencias, establecer conexiones y abordar problemas. La información es el resultado del análisis de esos datos.
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box85"><b>Laboratorio 3, página 1</b></a>: <strong>Correlación</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 3, página 1</b></a>: <strong>Correlación</strong>
                     <p>Una <strong>correlación</strong> (<em>correlation</em>) es un tipo particular de información, es decir, una dependencia entre dos variables en una situación. Por ejemplo, en la primera imagen aquí, mientras una variable sube, la otra baja. También es una correlación cuando una variable sube o baja y la otra cambia de la misma manera.
                     </p>
                     <div class="center">
@@ -141,12 +141,12 @@
                     </div>
                 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box86"><b>Laboratorio 3, página 1</b></a>: <strong>Insight</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 3, página 1</b></a>: <strong>Insight</strong>
             <div class="ap-standard">DAT-2.E.4</div>
             <p><strong>Insight</strong> es una conclusión significativa extraída del análisis de la información.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box87"><b>Laboratorio 3, página 3</b></a>: <strong>Registros</strong>, <strong>campos</strong> y <strong>columnas</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 3</b></a>: <strong>Registros</strong>, <strong>campos</strong> y <strong>columnas</strong>
             <ul>
                 <li>Un <strong>registro</strong> (<em>record</em>) es una fila de un conjunto de datos (distinta de la primera fila, que contiene los títulos de las columnas). Un registro único puede ser los datos de un estudiante de su escuela, los datos de un terremoto que ocurrió, los datos de un hospital en los EE. UU., o los datos de un contacto en tu lista de contactos. En otras palabras, un registro es un segmento horizontal del conjunto de datos.</li>
                 <li>Un <strong>campo</strong> (<em>field</em>) es un elemento de un registro en un conjunto de datos. Puede ser el tutor o maestro de una persona, la magnitud de un terremoto en Los Ángeles la semana pasada, el propietario de un hospital en Chicago, o el número de teléfono de una persona en tu lista de contactos.</li>
@@ -155,28 +155,28 @@
             <img class="indent" data-gifffer="/bjc-r/img/5-algorithms/cars-table-view-parts.gif" height="300px" alt="Animación de tres fotogramas del reporte del conjunto de datos de automóviles presentado como una tabla con columnas y filas; en el primer fotograma, se destaca la cuarta fila de la tabla y se etiqueta como 'registro (fila)'; en el segundo fotograma, se destaca la tercera columna de la tabla y se etiqueta como 'columna'; en el tercer fotograma, se destaca la celda en la cuarta fila y tercera columna y se etiqueta como 'campo'" title="Animación de tres fotogramas del reporte del conjunto de datos de automóviles presentado como una tabla con columnas y filas; en el primer fotograma, se destaca la cuarta fila de la tabla y se etiqueta como 'registro (fila)'; en el segundo fotograma, se destaca la tercera columna de la tabla y se etiqueta como 'columna'; en el tercer fotograma, se destaca la celda en la cuarta fila y tercera columna y se etiqueta como 'campo'">
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box88"><b>Laboratorio 3, página 3</b></a>: <strong>Limpieza de datos</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 3, página 3</b></a>: <strong>Limpieza de datos</strong>
             <div class="ap-standard">DAT-2.C.4, DAT-2.E.2</div>
             <p><strong>Limpieza de datos</strong> (<em>cleaning data</em>) es el proceso de hacer los datos uniformes <em>sin cambiar su significado</em> (como el reemplazo de abreviaturas, ortografía y mayúsculas por la palabra deseada o la conversión de millas a kilómetros). Los programadores pueden utilizar programas para filtrar y limpiar los datos digitales, obteniendo así una mayor visión y conocimiento.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box89"><b>Laboratorio 3, página 5</b></a>: <strong>Clasificar los datos</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 5</b></a>: <strong>Clasificar los datos</strong>
                 <div class="ap-standard">DAT-2.E.3 solamente clasificando</div>
                 <p><strong>Clasificar los datos</strong> (<em>classifying data</em>) es extraer grupos de datos con una característica en común.</p>
             </div>
 
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box90"><b>Laboratorio 3, página 5</b></a>: <strong>Modo</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 3, página 5</b></a>: <strong>Modo</strong>
 							<p>El <strong>modo</strong> (<em>mode</em>) de un conjunto de datos es el valor que aparece con más frecuencia.</p>
 						</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box91"><b>Laboratorio 3, página 6</b></a>: <strong>Metadatos</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 6</b></a>: <strong>Metadatos</strong>
             <div class="ap-standard">DAT-2.B.1</div>
             <p>Los <strong>metadatos</strong> (<em>metadata</em>) son datos sobre datos. Por ejemplo, el dato puede ser una imagen, mientras que los metadatos pueden incluir la fecha de creación o el tamaño del archivo de la imagen.</p>
         </div>
 <h3>Laboratorio 4: Problemas irresolubles e indecidibles</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box92"><b>Laboratorio 4, página 1</b></a>: <strong>Prueba por contradicción</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 1</b></a>: <strong>Prueba por contradicción</strong>
             	<p>
                     Una <strong>prueba por contradicción</strong> (<em>proof by contradition</em>) es una prueba de dos pasos para saber si algo es falso que se realiza:
                     </p>
@@ -187,12 +187,12 @@
                 
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box93"><b>Laboratorio 4, página 1</b></a>: <strong>Declaración indecidible</strong> vs. <strong>declaración autocontradictoria</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 4, página 1</b></a>: <strong>Declaración indecidible</strong> vs. <strong>declaración autocontradictoria</strong>
             	<p>Una declaración <strong>indecidible</strong> (<em>undecidable</em>) puede ser verdadera o falsa; no sabemos cuál.</p>
                 <p>Una declaración <strong>autocontradictoria</strong> (<em>self-contradictory</em>) no puede ser verdadera ni falsa.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/2-halting-problem.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html" id="box94"><b>Laboratorio 4, página 2</b></a>: <strong>Bucle infinito</strong>, <strong>problema irresoluble</strong> y <strong>problema indecidible</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/2-halting-problem.es.html?topic=nyc_bjc/5-algorithms.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 4, página 2</b></a>: <strong>Bucle infinito</strong>, <strong>problema irresoluble</strong> y <strong>problema indecidible</strong>
             <p>Un <strong>bucle infinito</strong> (<em>infinite loop</em>) es una secuencia de instrucciones de computadora que se repite para siempre.</p>
             <p>Un <strong>problema irresoluble</strong> (<em>unsolvable problem</em>) es aquel para el que nunca se puede escribir un algoritmo para encontrar la solución.</p>
             <p>Un <strong>problema indecidible</strong> (<em>undecidable problem</em>) es aquel para el que nunca se puede escribir un algoritmo que siempre dé una <em>decisión verdadero/falso</em> correcta para cada valor de entrada. Los problemas indecidibles son una subcategoría de problemas irresolubles que incluyen solo problemas que deberían tener una respuesta sí/no (como: ¿mi código tiene un error?).</p>

--- a/cur/programming/5-algorithms/unit-5-vocab.html
+++ b/cur/programming/5-algorithms/unit-5-vocab.html
@@ -13,7 +13,7 @@
 <h2>Unit 5: Algorithms and Simulations</h2>
 <h3>Lab 1: Search Algorithms and Efficiency</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box71"><b>Lab 1, Page 2</b></a>: <strong>Problem</strong> vs. <strong>Instance of a Problem</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 2</b></a>: <strong>Problem</strong> vs. <strong>Instance of a Problem</strong>
             <div class="ap-standard">AAP-4.A.1</div>
             <ul>
                 <li>A <strong>problem</strong> is a general description of a task that may (or may not) be solved algorithmically.</li>
@@ -21,7 +21,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box72"><b>Lab 1, Page 2</b></a>: <strong>Linear Search</strong> vs. <strong>Sequential Search</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/2-how-many-five-letter-words.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 2</b></a>: <strong>Linear Search</strong> vs. <strong>Sequential Search</strong>
             <ul>
                 <li>An algorithm takes <strong>linear time</strong> if multiplying the input size by ten multiplies the time required by ten.<br>
                 <img class="indent noshadow" style="height:300px" src="/bjc-r/img/5-algorithms/size-vs-time.png" alt="graph of size vs. time showing a straight line through the origin and up to the right with the points for x=10,000 and x=100,000 marked" title="graph of size vs. time showing a straight line through the origin and up to the right with the points for x=10,000 and x=100,000 marked">
@@ -32,7 +32,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box73"><b>Lab 1, Page 3</b></a>: <strong>Binary Search</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/3-spell-checker.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 3</b></a>: <strong>Binary Search</strong>
         	<div class="ap-standard">AAP-2.P.1, AAP-2.P.2</div>
             <p>A <strong>binary search</strong> algorithm starts in the middle of a <em>sorted</em> list and repeatedly eliminates half the list until either the desired value is found or all elements have been eliminated.</p>
             <div class="ap-standard">AAP-2.O.1</div>
@@ -40,12 +40,12 @@
             <p>Linear search does a <em>complete</em> traversal of the list. Binary search saves time by doing a <em>partial</em> traversal of the list.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/4-efficiency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box74"><b>Lab 1, Page 4</b></a>: <strong>Efficiency</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/4-efficiency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 4</b></a>: <strong>Efficiency</strong>
             <div class="ap-standard">AAP-4.A.3</div>
             <p>The relationship between the input size and the number of steps required to solve a problem is the <strong>efficiency</strong> of the algorithm used to solve the problem.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box75"><b>Lab 1, Page 5</b></a>: <strong>Linear Time</strong>, <strong>Sublinear Time</strong>, <strong>Constant Time</strong>, and <strong>Quadratic Time</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 5</b></a>: <strong>Linear Time</strong>, <strong>Sublinear Time</strong>, <strong>Constant Time</strong>, and <strong>Quadratic Time</strong>
             <ul>
                 <li>An algorithm takes <strong>linear time</strong> the number of steps is proportional to the input size; doubling the input size doubles the time required.</li>
                 <li>An algorithm takes <strong>sublinear time</strong> if the number of steps grows more slowly than the size.</li>
@@ -54,7 +54,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box76"><b>Lab 1, Page 5</b></a>: <strong>Polynomial Time</strong> and <strong>Exponential Time</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/5-categorizing-algorithms.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 5</b></a>: <strong>Polynomial Time</strong> and <strong>Exponential Time</strong>
             <ul>
                 <li>
                     An algorithm takes <strong>polynomial time</strong> if the number of steps is less than or equal to a power of the size of the input, such as constant (<em>n</em><sup>0</sup>), sublinear, linear (<em>n</em><sup>1</sup>), quadratic (<em>n</em><sup>2</sup>), or cubic (<em>n</em><sup>3</sup>).
@@ -66,7 +66,7 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box77"><b>Lab 1, Page 6</b></a>: <strong>Decision Problem</strong> vs. <strong>Optimization Problem</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 6</b></a>: <strong>Decision Problem</strong> vs. <strong>Optimization Problem</strong>
           <div class="ap-standard">AAP-4.A.2</div>
             <ul>
                 <li>A <strong>decision problem</strong> is a problem with a true/false answer (for example, "is 5,825,496,221 a prime number?").</li>
@@ -74,13 +74,13 @@
             </ul>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box78"><b>Lab 1, Page 6</b></a>: <strong>Decidable Problem</strong> vs. <strong>Undecidable Problem</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/6-heuristics.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 6</b></a>: <strong>Decidable Problem</strong> vs. <strong>Undecidable Problem</strong>
             <div class="ap-standard">AAP-4.B.1, AAP-4.B.2, AAP-4.B.3</div>
             <p>A <strong>decidable</strong> problem a decision problem for which it's possible to write an algorithm that will give a correct output for all inputs. </p>
             <p>An <strong>undecidable</strong> problem is the opposite. It's <em>not</em> possible to write an algorithm that will give a correct output for all inputs—even though it might be possible for some of them. </p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box79"><b>Lab 1, Page 8</b></a>: <strong>Sequential Computing</strong> vs. <strong>Parallel Computing</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 8</b></a>: <strong>Sequential Computing</strong> vs. <strong>Parallel Computing</strong>
             <div class="ap-standard">CSN-2.A.1, CSN-2.A.2</div>
             <p>
                 This section covers two computational models:
@@ -92,18 +92,18 @@
             
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box80"><b>Lab 1, Page 8</b></a>: <strong>Distributed Computing</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 8</b></a>: <strong>Distributed Computing</strong>
             <div class="ap-standard">CSN-2.A.3</div>
             <p><strong>Distributed computing</strong> is a form of parallel computing that uses multiple computers (perhaps even spread out around the world).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box81"><b>Lab 1, Page 8</b></a>: <strong>Processor</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-3"><b>Lab 1, Page 8</b></a>: <strong>Processor</strong>
                 <p>A <strong>processor</strong> is a piece of circuitry inside a computer that processes the instructions from computer programs.</p>
                 <p class="center"><img src="/bjc-r/img/6-computers/Hardware_img/CPU_small.jpg" alt="CPU" title="CPU"></p>
                 <p><small>Image credit: Wikipedia user Solipsist</small></p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box82"><b>Lab 1, Page 8</b></a>: <strong>Speedup</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/1-searching-lists/8-sequential.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-4"><b>Lab 1, Page 8</b></a>: <strong>Speedup</strong>
             <div class="ap-standard">CSN-2.A.7</div>
             <p>
                 Programmers refer to the <strong>speedup</strong> of parallel solution to describe how many times as fast the parallel solution is compared to the sequential solution:<br>
@@ -112,13 +112,13 @@
         </div>
 <h3>Lab 2: Simulations</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/2-simulation/1-intro-to-simulations.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box83"><b>Lab 2, Page 1</b></a>: <strong>Simulations</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/2-simulation/1-intro-to-simulations.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Simulations</strong>
             <div class="ap-standard">AAP-3.F.1, AAP-3.F.2</div>
             <p><strong>Simulations</strong> are computer representations of real things or situations that vary over time. A simulation is an abstraction designed for a particular purpose.</p>
         </div>
 <h3>Lab 3: Turning Data into Information</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box84"><b>Lab 3, Page 1</b></a>: <strong>Data</strong> vs. <strong>Information</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Data</strong> vs. <strong>Information</strong>
             <div class="ap-standard">DAT-2.A.1</div>
             <ul>
                 <li>
@@ -130,7 +130,7 @@
 <div class="ap-standard">DAT-2.A.2</div>Data provide opportunities for identifying trends, making connections, and addressing problems. Information is the result of analyzing that data.
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box85"><b>Lab 3, Page 1</b></a>: <strong>Correlation</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 3, Page 1</b></a>: <strong>Correlation</strong>
                     <p>
                         A <strong>correlation</strong> is a particular kind of information, namely a dependence between two variables. For example in the first picture here, as one variable goes up the other goes down. It's also a correlation when as one variable goes up or down the other changes in the same manner.
                     </p>
@@ -146,12 +146,12 @@
                     </div>
                 </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box86"><b>Lab 3, Page 1</b></a>: <strong>Insight</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/1-health-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-3"><b>Lab 3, Page 1</b></a>: <strong>Insight</strong>
             <div class="ap-standard">DAT-2.E.4</div>
             <p><strong>Insight</strong> is a meaningful conclusion drawn from analyzing information.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box87"><b>Lab 3, Page 3</b></a>: <strong>Records</strong>, <strong>Fields</strong>, and <strong>Columns</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 3</b></a>: <strong>Records</strong>, <strong>Fields</strong>, and <strong>Columns</strong>
             <ul>
                 <li>A <strong>record</strong> is one row in a dataset (other than the first row, which contains the column headings). A single record might be the data for one student in your school, the data for one earthquake that happened, the data for one hospital in the U.S, or the data for one contact in your contact list. In other words, a record is a horizontal slice of the dataset.</li>
                 <li>A <strong>field</strong> is one item of a record in a dataset. It might be one person's homeroom teacher, the magnitude of an earthquake in Los Angeles last week, the owner of one hospital in Chicago, or the phone number of one person in your contact list.</li>
@@ -160,27 +160,27 @@
             <img height="231" class="indent" data-gifffer="/bjc-r/img/5-algorithms/cars-table-view-parts.gif" alt="three frame animation of the report of cars dataset displayed as a table with columns and rows; in the first frame, the fourth row of the table is highlighted and labeled 'record (row)'; in the second frame, the third column of the table is highlighted and labeled 'column'; in the third frame, the cell in the fourth row and third column is highlighted and labeled 'field'" title="three frame animation of the report of cars dataset displayed as a table with columns and rows; in the first frame, the fourth row of the table is highlighted and labeled 'record (row)'; in the second frame, the third column of the table is highlighted and labeled 'column'; in the third frame, the cell in the fourth row and third column is hightlighted and labeled 'field'">
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box88"><b>Lab 3, Page 3</b></a>: <strong>Cleaning Data</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/3-importing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 3, Page 3</b></a>: <strong>Cleaning Data</strong>
             <div class="ap-standard">DAT-2.C.4, DAT-2.E.2</div>
             <p><strong>Cleaning data</strong> is the process of making the data uniform <em>without changing its meaning</em> (such as replacing abbreviations, spellings, and capitalizations with the intended word or converting miles to kilometers). Programmers can use programs to filter and clean digital data, thereby gaining insight and knowledge.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box89"><b>Lab 3, Page 5</b></a>: <strong>Classifying Data</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 5</b></a>: <strong>Classifying Data</strong>
                 <div class="ap-standard">DAT-2.E.3 classifying only</div>
                 <p><strong>Classifying data</strong> means distributing data into groups based on common characteristics.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box90"><b>Lab 3, Page 5</b></a>: <strong>Mode</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/5-visualizing-data.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 3, Page 5</b></a>: <strong>Mode</strong>
 						<p>The <strong>mode</strong> of a data set is the value that appears most often in it.</p>
 					</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box91"><b>Lab 3, Page 6</b></a>: <strong>Metadata</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/3-turning-data-information/6-metadata.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 6</b></a>: <strong>Metadata</strong>
             <div class="ap-standard">DAT-2.B.1</div>
             <p><strong>Metadata</strong> are data about data. For example, the piece of data may be an image, while the metadata may include the date of creation or the file size of the image.</p>
         </div>
 <h3>Lab 4: Unsolvable and Undecidable Problems</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box92"><b>Lab 4, Page 1</b></a>: <strong>Proof by Contradiction</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Proof by Contradiction</strong>
             	<p>
                     A <strong>proof by contradiction</strong> is a two-step proof that a statement is false, which is done by
                     </p>
@@ -191,19 +191,19 @@
                 
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box93"><b>Lab 4, Page 1</b></a>: <strong>Undecidable Statement</strong> vs <strong>Self-Contradictory Statement</strong>  
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/1-logical-inconsistency.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 4, Page 1</b></a>: <strong>Undecidable Statement</strong> vs <strong>Self-Contradictory Statement</strong>  
             	<p>An <strong>undecidable</strong> statement might be true or might be false; we don't know which.</p>
                 <p>A <strong>self-contradictory</strong> statement can be neither true nor false.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/2-halting-problem.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box94"><b>Lab 4, Page 2</b></a>: <strong>Infinite Loop</strong>, <strong>Unsolvable Problem</strong>, and <strong>Undecidable Problem</strong>
+<a href="/bjc-r/cur/programming/5-algorithms/4-unsolvable-undecidable/2-halting-problem.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 4, Page 2</b></a>: <strong>Infinite Loop</strong>, <strong>Unsolvable Problem</strong>, and <strong>Undecidable Problem</strong>
             <p>An <strong>infinite loop</strong> is a sequence of computer instructions that repeats forever.</p>
             <p>An <strong>unsolvable problem</strong> is one for which no algorithm can ever be written to find the solution.</p>
             <p>An <strong>undecidable problem</strong> is one for which no algorithm can ever be written that will always give a correct <em>true/false decision</em> for every input value. Undecidable problems are a subcategory of unsolvable problems that include only problems that should have a yes/no answer (such as: does my code have a bug?).</p>
         </div>
 <h3>Lab 7: Other Programming Languages (Optional)</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/7-other-programming-languages/1-sequential-languages.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box95"><b>Lab 7, Page 1</b></a>
+<a href="/bjc-r/cur/programming/5-algorithms/7-other-programming-languages/1-sequential-languages.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-1"><b>Lab 7, Page 1</b></a>
 			<div class="sidenote">You learned about reporters and commands on <a href="/bjc-r/cur/programming/1-introduction/2-gossip-and-greet/4-making-a-new-block.html?topic=nyc_bjc/1-intro-loops.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 1 Lab 2 Page 4: Making Your Own Block">Unit 1 Lab 2 Page 4: Making Your Own Block</a> and about predicates on <a href="/bjc-r/cur/programming/2-complexity/1-variables-games/2-checking-player-guess.html?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 2 Lab 1 Page 2: Checking the Player's Guess">Unit 2 Lab 1 Page 2: Checking the Player's Guess</a>.</div>
 			<p>
 				<strong>Multi-paradigm</strong> languages take ideas from several different approaches to programming style. Here are a few approaches you have seen in Snap<em>!</em>:
@@ -221,7 +221,7 @@
 			<p style="clear: both; height: 0px;"></p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/5-algorithms/7-other-programming-languages/1-sequential-languages.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html" id="box96"><b>Lab 7, Page 1</b></a>
+<a href="/bjc-r/cur/programming/5-algorithms/7-other-programming-languages/1-sequential-languages.html?topic=nyc_bjc/5-algorithms.topic&course=bjc4nyc.html#vocab-2"><b>Lab 7, Page 1</b></a>
 			<p>The <strong>syntax</strong> of a language is the notation it uses (punctuation, words reserved for specific purposes, etc.).  Human languages have syntax, too: nouns vs. verbs, commas vs. semicolons, and so on.</p>
 			<div class="todo">
 <p>The <strong>semantics</strong> of a language refers to the meaning or purpose of each piece of syntax.</p>I'm not sure why this was on the page. Semantics is not mentioned anywhere else and an irrelevant vocab term feels like an odd way to wrap up. --MF, 12/20/21</div>

--- a/cur/programming/6-computers/unit-6-self-check.es.html
+++ b/cur/programming/6-computers/unit-6-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Jerarquía de abstracción computacional</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Identify this higher order function." hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box100"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -53,7 +53,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is TRUE about a low-level language?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box101"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -86,7 +86,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is TRUE about a program written in a high-level programming language?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_6_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box102"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
                         <div class="prompt">Un programa está escrito en un lenguaje de programación de alto nivel. Identifica la declaración correcta sobre el programa.</div>
@@ -111,7 +111,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="¿Qué expresión reportara VERDADERO?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_9" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box103"><strong>laboratorio 1, página 9</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 9</strong></a>
 </div>
 
                         <div class="prompt">
@@ -142,7 +142,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Qué compuerta lógica reporta VERDADERO?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_6_1_9" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box104"><strong>laboratorio 1, página 9</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 9</strong></a>
 </div>
 
                         <div class="prompt">
@@ -185,7 +185,7 @@
                     </div><h2>Laboratorio 2: Historia e impacto de las computadoras</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which is TRUE according to Moore's Law?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_2_2" shuffle="true">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#box105"><strong>laboratorio 2, página 2</strong></a>
+   de <a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 2, página 2</strong></a>
 </div>
 
                         <div class="prompt">Como Gordon Moore observó en 1965, los datos muestran que las velocidades de procesamiento por computadora se duplican aproximadamente cada dos años. Las empresas de tecnología utilizan esta observación, ahora conocida como "Ley de Moore", en su planificación. De lo siguiente, identifica cuál describe mejor cómo las empresas de tecnología pueden utilizar la Ley de Moore en la planificación.</div>

--- a/cur/programming/6-computers/unit-6-self-check.html
+++ b/cur/programming/6-computers/unit-6-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Computer Abstraction Hierarchy</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Identify this higher-order function." hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box99"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -53,7 +53,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is TRUE about a low-level language?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box100"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -85,7 +85,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which is TRUE about a program written in a high-level programming language?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_6_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box101"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/03-software-languages.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">A program is written in a high-level programming language.  Identify the correct statement about the program?</div>
@@ -110,7 +110,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which expression will report TRUE?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_1_9" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box102"><strong>Lab 1, Page 9</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 9</strong></a>
 </div>
 
                         <div class="prompt">
@@ -141,7 +141,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="Which logic gate will report TRUE?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_6_1_9" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box103"><strong>Lab 1, Page 9</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 9</strong></a>
 </div>
 
                         <div class="prompt">
@@ -184,7 +184,7 @@
                     </div><h2>Lab 2: History of Computers</h2>
 <div class="assessment-data" type="multiplechoice" identifier="Which is TRUE according to Moore's Law?" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_6_2_2" shuffle="true">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#box104"><strong>Lab 2, Page 2</strong></a>
+   from <a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 2, Page 2</strong></a>
 </div>
 
                         <div class="prompt">As Gordon Moore observed in 1965, data show that computer processing speeds roughly double every two years. Technology companies use this observation, now known as "Moore’s Law,’ in their planning.  From the following, identify which one best describes how technology companies can use Moore’s Law in planning.</div>

--- a/cur/programming/6-computers/unit-6-vocab.es.html
+++ b/cur/programming/6-computers/unit-6-vocab.es.html
@@ -13,28 +13,28 @@
 <h2>Unidad 6: ¿Cómo funcionan las computadoras?</h2>
 <h3>Laboratorio 1: Jerarquía de abstracción computacional</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/01-abstraction.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html" id="box95"><b>Laboratorio 1, página 1</b></a>: <strong>Análogo</strong> vs. <strong>digital</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/01-abstraction.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 1</b></a>: <strong>Análogo</strong> vs. <strong>digital</strong>
 			<p>Digital y análogo son conceptos opuestos. <strong>Digital</strong> significa información que es representada en <em>unos y ceros</em>. <strong>Análogo</strong> (<em>analog</em>) significa información que es representada por señales que <em>varían constantemente</em> (es decir, que incluyen los valores intermedios).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/04-software-libraries.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html" id="box96"><b>Laboratorio 1, página 4</b></a><strong>: Bibliotecas de software</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/04-software-libraries.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 4</b></a><strong>: Bibliotecas de software</strong>
 			<div class="ap-standard">AAP-3.D.1, AAP-3.D.2, AAP-3.D.3</div>
             <ul>
                 <li>Una <strong>biblioteca de software</strong> (<em>software library</em>) es un paquete de procedimientos que puedes importar a tu programa. Una biblioteca es un tipo de abstracción: no es necesario que conozcas los detalles de cómo está codificada. Puedes construir bibliotecas por ti mismo, o puedes usar una que haya escrito otra persona.</li>
             </ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/06-digital-architecture.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html" id="box97"><b>Laboratorio 1, página 6</b></a>: <strong>Lenguaje de máquina</strong> y <strong>arquitectura</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/06-digital-architecture.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 6</b></a>: <strong>Lenguaje de máquina</strong> y <strong>arquitectura</strong>
 			<p><strong>Lenguaje de máquina</strong> (<em>machine language</em>) es el lenguaje de programación de más bajo nivel; es entendido directamente por el hardware de la computadora.</p>
             <p><strong>Arquitectura</strong> (<em>architecture</em>) es una abstracción, una especificación del lenguaje de máquina. También indica cómo se conecta el procesador a la memoria. No especifica la circuitería; la misma arquitectura se puede construir como circuitería de muchas maneras diferentes.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/08-digital-IC.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html" id="box98"><b>Laboratorio 1, página 8</b></a>: <strong>Circuito integrado</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/08-digital-IC.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 8</b></a>: <strong>Circuito integrado</strong>
         	<p>Un <strong>circuito integrado</strong> (<em>integrated circuit</em>) ("CI" or "chip") es un dispositivo físico individual que contiene millones o miles de millones de partes eléctricas básicas. Un procesador es un IC, pero no todos los procesadores son CI; También hay chips de proposito especial dentro de una computadora.</p>
         </div>
 <h3>Laboratorio 2: Historia e impacto de las computadoras</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html" id="box99"><b>Laboratorio 2, página 2</b></a>: <strong>Ley de Moore</strong>
+<a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 2, página 2</b></a>: <strong>Ley de Moore</strong>
 			<p>La <strong>Ley de Moore</strong> (<em>Moore's Law</em>) es la predicción de que la cantidad de transistores en un chip se duplica cada año.</p>
 		</div>
 

--- a/cur/programming/6-computers/unit-6-vocab.html
+++ b/cur/programming/6-computers/unit-6-vocab.html
@@ -13,11 +13,11 @@
 <h2>Unit 6: How Computers Work</h2>
 <h3>Lab 1: Computer Abstraction Hierarchy</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/01-abstraction.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html" id="box97"><b>Lab 1, Page 1</b></a>: <strong>Analog</strong> vs. <strong>Digital</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/01-abstraction.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Analog</strong> vs. <strong>Digital</strong>
         	<p>Digital and analog are opposites. <strong>Digital</strong> means information that is represented as <em>ones and zeros</em>. <strong>Analog</strong> means information that is represented by signals that <em>vary continuously</em> (that is, including in-between values).</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/04-software-libraries.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html" id="box98"><b>Lab 1, Page 4</b></a>: <strong>Software Libraries</strong><!-- and <strong>APIs</strong>-->
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/04-software-libraries.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 4</b></a>: <strong>Software Libraries</strong><!-- and <strong>APIs</strong>-->
 			<div class="ap-standard">AAP-3.D.1, AAP-3.D.2, AAP-3.D.3</div>
             <ul>
                 <li>A <strong>software library</strong> is a package of procedures that you can import into your program. A library is a kind of abstraction: you don't have to know any of the details of how it's coded. You can build libraries yourself, or you can use one that someone else wrote.</li>
@@ -26,17 +26,17 @@
             </ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/06-digital-architecture.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html" id="box99"><b>Lab 1, Page 6</b></a>: <strong>Machine Language</strong> and <strong>Architecture</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/06-digital-architecture.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 6</b></a>: <strong>Machine Language</strong> and <strong>Architecture</strong>
 			<p><strong>Machine language</strong> is the lowest-level programming language; it is directly understood by the computer hardware.</p>
             <p><strong>Architecture</strong> is an abstraction, a specification of the machine language. It also tells how the processor connects to the memory. It doesn't specify the circuitry; the same architecture can be built as circuitry in many different ways.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/1-abstraction/08-digital-IC.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html" id="box100"><b>Lab 1, Page 8</b></a>: <strong>Integrated Circuit</strong>
+<a href="/bjc-r/cur/programming/6-computers/1-abstraction/08-digital-IC.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 8</b></a>: <strong>Integrated Circuit</strong>
         	<p>An <strong>integrated circuit</strong> ("IC" or "chip") is a single physical device that contains millions or billions of basic electrical parts. A processor is an IC, but not all ICs are processors; there are also special-purpose chips inside a computer.</p>
         </div>
 <h3>Lab 2: History of Computers</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html" id="box101"><b>Lab 2, Page 2</b></a>: <strong>Moore's Law</strong>
+<a href="/bjc-r/cur/programming/6-computers/2-history-impact/2-moore.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html#vocab-1"><b>Lab 2, Page 2</b></a>: <strong>Moore's Law</strong>
 			<p><strong>Moore's Law</strong> is the prediction that the number of transistors that fit on one chip doubles every year.</p>
 		</div>
 

--- a/cur/programming/7-recursion/unit-7-self-check.es.html
+++ b/cur/programming/7-recursion/unit-7-self-check.es.html
@@ -13,7 +13,7 @@
 <h2>Laboratorio 1: Árboles</h2>
 <div class="assessment-data" type="multiplechoice" identifier="number-of-levels" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_7_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box106"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
 
@@ -64,7 +64,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="negative-size" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_7_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box107"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
 
@@ -122,7 +122,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="negative-levels" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_7_1_3" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box108"><strong>laboratorio 1, página 3</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 1, página 3</strong></a>
 </div>
 
 
@@ -178,7 +178,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="asymmetric" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_7_1_4" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box109"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-1"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
 
@@ -221,7 +221,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="5-branches" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_7_1_4" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box110"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-2"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
 
@@ -264,7 +264,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="growing-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_7_1_4" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box111"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-3"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
 
@@ -307,7 +307,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="not-shrinking-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_7_1_4" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box112"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-4"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
 
@@ -350,7 +350,7 @@
             </div>
         </div><div class="assessment-data" type="multiplechoice" identifier="square-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri5_7_1_4" shuffle="false">
 <div class="additional-info">
-   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#box113"><strong>laboratorio 1, página 4</strong></a>
+   de <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#self-check-5"><strong>laboratorio 1, página 4</strong></a>
 </div>
 
 

--- a/cur/programming/7-recursion/unit-7-self-check.html
+++ b/cur/programming/7-recursion/unit-7-self-check.html
@@ -13,7 +13,7 @@
 <h2>Lab 1: Trees</h2>
 <div class="assessment-data" type="multiplechoice" identifier="number-of-levels" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_7_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box105"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">
@@ -41,7 +41,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="negative-size" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_7_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box106"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">What would happen if you changed the input <var>size</var> to be -100? (Don't use Snap<em>!</em>. The point is to think about it.)</div>
@@ -70,7 +70,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="negative-levels" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_7_1_3" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box107"><strong>Lab 1, Page 3</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/3-tree-input-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 1, Page 3</strong></a>
 </div>
 
                         <div class="prompt">What would happen if you changed the input <var>level</var> to be -4? (Don't use Snap<em>!</em>. The point is to think about it.)</div>
@@ -99,7 +99,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="asymmetric" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri1_7_1_4" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box108"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-1"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -123,7 +123,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="5-branches" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri2_7_1_4" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box109"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-2"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -147,7 +147,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="growing-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri3_7_1_4" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box110"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-3"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -171,7 +171,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="not-shrinking-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri4_7_1_4" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box111"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-4"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">
@@ -195,7 +195,7 @@
                         </div>
                     </div><div class="assessment-data" type="multiplechoice" identifier="square-tree" hasinlinefeedback="true" maxchoices="1" responseidentifier="ri5_7_1_4" shuffle="false">
 <div class="additional-info">
-   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#box112"><strong>Lab 1, Page 4</strong></a>
+   from <a href="/bjc-r/cur/programming/7-recursion/1-trees/4-tree-variations-self-check.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#self-check-5"><strong>Lab 1, Page 4</strong></a>
 </div>
 
                         <div class="prompt">

--- a/cur/programming/7-recursion/unit-7-vocab.es.html
+++ b/cur/programming/7-recursion/unit-7-vocab.es.html
@@ -13,20 +13,20 @@
 <h2>Unidad 7: Fractales y Recursión</h2>
 <h3>Laboratorio 1: Árboles</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html" id="box100"><b>Laboratorio 1, página 1</b></a>: <strong>Fractal</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 1</b></a>: <strong>Fractal</strong>
                 <p>Un <strong>fractal</strong> es un patrón repetido infinito formado por copias (o ligeras variaciones) de la misma forma. En esta imagen, la rama verde tiene (esencialmente) la misma forma que la imagen completa.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html" id="box101"><b>Laboratorio 1, página 1</b></a>: <strong>Transparencia del estado</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#vocab-2"><b>Laboratorio 1, página 1</b></a>: <strong>Transparencia del estado</strong>
 			<p><strong>Transparencia del estado</strong> (<em>state transparency</em>): volver a poner todo (objeto, lápiz, etc.) exactamente como estaba cuando comenzaste, es importante cuando los bloques dependen de otros bloques. Por lo general, esto significa devolver el objeto a la misma posición y dirección, y el lápiz al mismo color y tamaño que tenían.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html" id="box102"><b>Laboratorio 1, página 1</b></a>: <strong>Recursividad</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#vocab-3"><b>Laboratorio 1, página 1</b></a>: <strong>Recursividad</strong>
             <p>Usar un bloque dentro de sí mismo se llama <strong>recursividad</strong> (<em>recursion</em>).</p>
             <div class="endnote">Aprendiste sobre la recursividad en <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc%2F3-lists.topic&course=bjc4nyc.html&novideo&noassignment" title="Unidad 3 Laboratorio 1 Página 3: Usar la abstracción para anidar triángulos">Unidad 3 Laboratorio 1 Página 3: Usar la abstracción para anidar triángulos</a>.</div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/2-base-case.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html" id="box103"><b>Laboratorio 1, página 2</b></a>: <strong>Caso base</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/2-base-case.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 1, página 2</b></a>: <strong>Caso base</strong>
 			<p>Esta versión diferente para el nivel más bajo de un script recursivo se denomina <strong>caso base</strong> (<em>base case</em>).</p>
 		</div>
 

--- a/cur/programming/7-recursion/unit-7-vocab.html
+++ b/cur/programming/7-recursion/unit-7-vocab.html
@@ -13,20 +13,20 @@
 <h2>Unit 7: Fractals and Recursion</h2>
 <h3>Lab 1: Trees</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html" id="box102"><b>Lab 1, Page 1</b></a>: <strong>Fractal</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Fractal</strong>
                 <p>A <strong>fractal</strong> is an infinite repeating pattern made up of copies (or slight variations) of the same shape. In this picture, the green branch is (essentially) the same shape as the entire picture.</p>
             </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html" id="box103"><b>Lab 1, Page 1</b></a>: <strong>State Transparency</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#vocab-2"><b>Lab 1, Page 1</b></a>: <strong>State Transparency</strong>
             <p><strong>State transparency</strong> means putting everything back exactly as it was when you started. It is especially important when blocks depend on other blocks. Usually, this means returning the sprite to the same position and direction and returning the pen to the same color and size.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html" id="box104"><b>Lab 1, Page 1</b></a>: <strong>Recursion</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/1-recursive-tree.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#vocab-3"><b>Lab 1, Page 1</b></a>: <strong>Recursion</strong>
             <p>Using a procedure inside of itself is called <strong>recursion</strong>.</p>
             <div class="endnote">You learned about recursion on <a href="/bjc-r/cur/programming/3-lists/1-abstraction/3-fractal-art-recursive.html?topic=nyc_bjc%2F3-lists.topic&course=bjc4nyc.html&novideo&noassignment" title="Unit 3 Lab 1 Page 3: Using Abstraction to Nest Triangles">Unit 3 Lab 1 Page 3: Using Abstraction to Nest Triangles</a>.</div>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/7-recursion/1-trees/2-base-case.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html" id="box105"><b>Lab 1, Page 2</b></a>: <strong>Base Case</strong>
+<a href="/bjc-r/cur/programming/7-recursion/1-trees/2-base-case.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html#vocab-1"><b>Lab 1, Page 2</b></a>: <strong>Base Case</strong>
             <p>This different version for the lowest level of a recursive script is called the <strong>base case</strong>.</p>
         </div>
 

--- a/cur/programming/8-recursive-reporters/unit-8-vocab.es.html
+++ b/cur/programming/8-recursive-reporters/unit-8-vocab.es.html
@@ -13,7 +13,7 @@
 <h2>Unidad 8: Funciones recursivas</h2>
 <h3>Laboratorio 3: Subconjuntos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/8-recursive-reporters/3-subsets/1-ice-cream-bowls.es.html?topic=nyc_bjc/8-recursive-reporters.es.topic&course=bjc4nyc.html" id="box104"><b>Laboratorio 3, página 1</b></a>: <strong>Subconjunto</strong>
+<a href="/bjc-r/cur/programming/8-recursive-reporters/3-subsets/1-ice-cream-bowls.es.html?topic=nyc_bjc/8-recursive-reporters.es.topic&course=bjc4nyc.html#vocab-1"><b>Laboratorio 3, página 1</b></a>: <strong>Subconjunto</strong>
             <p>Un <strong>subconjunto</strong> (<em>subset</em>) es una selección de elementos de un conjunto; puede ser ninguno, todos o cualquier número intermedio.</p>
         </div>
 

--- a/cur/programming/8-recursive-reporters/unit-8-vocab.html
+++ b/cur/programming/8-recursive-reporters/unit-8-vocab.html
@@ -13,7 +13,7 @@
 <h2>Unit 8: Recursive Functions</h2>
 <h3>Lab 3: Subsets</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/cur/programming/8-recursive-reporters/3-subsets/1-ice-cream-bowls.html?topic=nyc_bjc/8-recursive-reporters.topic&course=bjc4nyc.html" id="box106"><b>Lab 3, Page 1</b></a>: <strong>Subset</strong>
+<a href="/bjc-r/cur/programming/8-recursive-reporters/3-subsets/1-ice-cream-bowls.html?topic=nyc_bjc/8-recursive-reporters.topic&course=bjc4nyc.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Subset</strong>
             <p>A <strong>subset</strong> is a selection of items from a set; it can be none, all, or any number in between.</p>
         </div>
 

--- a/cur/programming/summaries/assessment-data1.html
+++ b/cur/programming/summaries/assessment-data1.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data2.html
+++ b/cur/programming/summaries/assessment-data2.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data3.html
+++ b/cur/programming/summaries/assessment-data3.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data4.html
+++ b/cur/programming/summaries/assessment-data4.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/4-internet/unit-4-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/4-internet/unit-4-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data5.html
+++ b/cur/programming/summaries/assessment-data5.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data6.html
+++ b/cur/programming/summaries/assessment-data6.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/6-computers/unit-6-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/6-computers/unit-6-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data7.html
+++ b/cur/programming/summaries/assessment-data7.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/7-recursion/unit-7-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/7-recursion/unit-7-self-check.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/assessment-data8.html
+++ b/cur/programming/summaries/assessment-data8.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/8-recursive-reporters/unit-8-self-check-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/topic/topic.html?topic=nyc_bjc/8-recursive-reporters.topic&course=bjc4nyc.html";
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +12,9 @@
 
 <body>
     <p>
-        If you are not automatically redirected, please
-        <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-self-check.html">click here</a>.
+        Unit 8 has no self-check page. If you are not automatically
+        redirected, please
+        <a href="/bjc-r/topic/topic.html?topic=nyc_bjc/8-recursive-reporters.topic&amp;course=bjc4nyc.html">go to the Unit 8 contents</a>.
     </p>
 </body>
 

--- a/cur/programming/summaries/exam1.html
+++ b/cur/programming/summaries/exam1.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-exam-reference.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/exam2.html
+++ b/cur/programming/summaries/exam2.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-exam-reference.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/exam3.html
+++ b/cur/programming/summaries/exam3.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-exam-reference.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/exam4.html
+++ b/cur/programming/summaries/exam4.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/4-internet/unit-4-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/topic/topic.html?topic=nyc_bjc/4-internet.topic&course=bjc4nyc.html";
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +12,9 @@
 
 <body>
     <p>
-        If you are not automatically redirected, please
-        <a href="/bjc-r/cur/programming/4-internet/unit-4-exam-reference.html">click here</a>.
+        Unit 4 has no exam reference page. If you are not automatically
+        redirected, please
+        <a href="/bjc-r/topic/topic.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html">go to the Unit 4 contents</a>.
     </p>
 </body>
 

--- a/cur/programming/summaries/exam5.html
+++ b/cur/programming/summaries/exam5.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-exam-reference.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/exam6.html
+++ b/cur/programming/summaries/exam6.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/6-computers/unit-6-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/topic/topic.html?topic=nyc_bjc/6-how-computers-work.topic&course=bjc4nyc.html";
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +12,9 @@
 
 <body>
     <p>
-        If you are not automatically redirected, please
-        <a href="/bjc-r/cur/programming/6-computers/unit-6-exam-reference.html">click here</a>.
+        Unit 6 has no exam reference page. If you are not automatically
+        redirected, please
+        <a href="/bjc-r/topic/topic.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html">go to the Unit 6 contents</a>.
     </p>
 </body>
 

--- a/cur/programming/summaries/exam7.html
+++ b/cur/programming/summaries/exam7.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/7-recursion/unit-7-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/topic/topic.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&course=bjc4nyc.html";
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +12,9 @@
 
 <body>
     <p>
-        If you are not automatically redirected, please
-        <a href="/bjc-r/cur/programming/7-recursion/unit-7-exam-reference.html">click here</a>.
+        Unit 7 has no exam reference page. If you are not automatically
+        redirected, please
+        <a href="/bjc-r/topic/topic.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html">go to the Unit 7 contents</a>.
     </p>
 </body>
 

--- a/cur/programming/summaries/exam8.html
+++ b/cur/programming/summaries/exam8.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/8-recursive-reporters/unit-8-Exam Reference-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/topic/topic.html?topic=nyc_bjc/8-recursive-reporters.topic&course=bjc4nyc.html";
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +12,9 @@
 
 <body>
     <p>
-        If you are not automatically redirected, please
-        <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-exam-reference.html">click here</a>.
+        Unit 8 has no exam reference page. If you are not automatically
+        redirected, please
+        <a href="/bjc-r/topic/topic.html?topic=nyc_bjc/8-recursive-reporters.topic&amp;course=bjc4nyc.html">go to the Unit 8 contents</a>.
     </p>
 </body>
 

--- a/cur/programming/summaries/vocab1.html
+++ b/cur/programming/summaries/vocab1.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/1-introduction/unit-1-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab2.html
+++ b/cur/programming/summaries/vocab2.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/2-complexity/unit-2-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab3.html
+++ b/cur/programming/summaries/vocab3.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/3-lists/unit-3-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab4.html
+++ b/cur/programming/summaries/vocab4.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/4-internet/unit-4-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/4-internet/unit-4-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab5.html
+++ b/cur/programming/summaries/vocab5.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab6.html
+++ b/cur/programming/summaries/vocab6.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/6-computers/unit-6-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/6-computers/unit-6-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab7.html
+++ b/cur/programming/summaries/vocab7.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/7-recursion/unit-7-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/7-recursion/unit-7-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/summaries/vocab8.html
+++ b/cur/programming/summaries/vocab8.html
@@ -3,7 +3,7 @@
 
 <head>
     <script>
-        window.location.href = "/bjc-r/cur/programming/8-recursive-reporters/unit-8-Vocabulary-reference.html" + window.location.search + window.location.hash;
+        window.location.href = "/bjc-r/cur/programming/8-recursive-reporters/unit-8-vocab.html" + window.location.search + window.location.hash;
     </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/cur/programming/vocab-index.es.html
+++ b/cur/programming/vocab-index.es.html
@@ -44,578 +44,578 @@
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="A">A</h2>
             <ol style="list-style-type: square">
-              <li>abierto, acceso   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>abierto, acceso   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>abierto, código   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>abierto, código   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>abstracción de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>abstracción de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>abstracción procesal   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box35">3.1.4</a>
+              <li>abstracción procesal   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-2">3.1.4</a>
               </li>
-              <li>abstracto, tipo de datos   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box39">3.2.1</a>
+              <li>abstracto, tipo de datos   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-6">3.2.1</a>
               </li>
-              <li>abstractos, tipo de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>abstractos, tipo de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>acceso abierto   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>acceso abierto   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>aceleración   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box82">5.1.8</a>
+              <li>aceleración   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-12">5.1.8</a>
               </li>
-              <li>ADT   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>ADT   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>algoritmo   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box6">1.3.1</a>
+              <li>algoritmo   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-7">1.3.1</a>
               </li>
-              <li>analógicos   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>analógicos   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>análogo   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box95">6.1.1</a>
+              <li>análogo   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-1">6.1.1</a>
               </li>
-              <li>ancho   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box66">4.4.3</a>
+              <li>ancho   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-22">4.4.3</a>
               </li>
-              <li>ancho de banda   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>ancho de banda   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
-              <li>anidada, sentencia condicional   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box28">2.3.3</a>
+              <li>anidada, sentencia condicional   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-17">2.3.3</a>
               </li>
-              <li>antimalware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>antimalware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>antimalware, software antivirus o   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>antimalware, software antivirus o   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>antivirus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>antivirus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>aplicación, interfaz de programa de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box31">2.4.2</a>
+              <li>aplicación, interfaz de programa de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-20">2.4.2</a>
               </li>
-              <li>argumento   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box7">1.3.3</a>
+              <li>argumento   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-8">1.3.3</a>
               </li>
-              <li>arquitectura   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box97">6.1.6</a>
+              <li>arquitectura   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>artificial, inteligencia   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>artificial, inteligencia   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>ataque DDoS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>ataque DDoS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>autocontradictoria   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box93">5.4.1</a>
+              <li>autocontradictoria   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-23">5.4.1</a>
               </li>
-              <li>autoridades de certificación   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box55">4.2.3</a>
+              <li>autoridades de certificación   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-11">4.2.3</a>
               </li>
-              <li>autorizado, punto de acceso no   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box58">4.2.5</a>
+              <li>autorizado, punto de acceso no   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-14">4.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="B">B</h2>
             <ol style="list-style-type: square">
-              <li>banda, ancho de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>banda, ancho de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
-              <li>base, caso   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box103">7.1.2</a>
+              <li>base, caso   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-4">7.1.2</a>
               </li>
-              <li>biblioteca de software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box30">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box96">6.1.4</a>
+              <li>biblioteca de software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-19">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-2">6.1.4</a>
               </li>
-              <li>binaria, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box73">5.1.3</a>
+              <li>binaria, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-3">5.1.3</a>
               </li>
-              <li>binaria, secuencia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box64">4.4.2</a>
+              <li>binaria, secuencia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-20">4.4.2</a>
               </li>
-              <li>bit   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box62">4.4.1</a>
+              <li>bit   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-18">4.4.1</a>
               </li>
-              <li>booleano, valor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>booleano, valor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>brecha digital   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box59">4.3.5</a>
+              <li>brecha digital   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-15">4.3.5</a>
               </li>
-              <li>bucle infinito   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box10">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>bucle infinito   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-11">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>búsqueda binaria   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box73">5.1.3</a>
+              <li>búsqueda binaria   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-3">5.1.3</a>
               </li>
-              <li>búsqueda lineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>búsqueda lineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>búsqueda secuencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>búsqueda secuencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>byte   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box63">4.4.1</a>
+              <li>byte   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-19">4.4.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="C">C</h2>
             <ol style="list-style-type: square">
-              <li>cadena   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box29">2.3.5</a>
+              <li>cadena   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-18">2.3.5</a>
               </li>
-              <li>campo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>campo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>caso base   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box103">7.1.2</a>
+              <li>caso base   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-4">7.1.2</a>
               </li>
-              <li>certificación, autoridades de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box55">4.2.3</a>
+              <li>certificación, autoridades de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-11">4.2.3</a>
               </li>
-              <li>ciencia ciudadana   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>ciencia ciudadana   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
-              <li>cifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box51">4.2.1</a>
+              <li>cifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-7">4.2.1</a>
               </li>
-              <li>cifrado de clave pública   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box53">4.2.3</a>
+              <li>cifrado de clave pública   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-9">4.2.3</a>
               </li>
-              <li>cifrado simétrico   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box52">4.2.1</a>
+              <li>cifrado simétrico   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-8">4.2.1</a>
               </li>
-              <li>circuito integrado   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box98">6.1.8</a>
+              <li>circuito integrado   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-4">6.1.8</a>
               </li>
-              <li>ciudadana, ciencia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>ciudadana, ciencia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
-              <li>clasificar los datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box89">5.3.5</a>
+              <li>clasificar los datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-19">5.3.5</a>
               </li>
-              <li>clon   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box37">3.1.5</a>
+              <li>clon   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-4">3.1.5</a>
               </li>
-              <li>código abierto   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>código abierto   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>código, segmento de   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box11">1.5.2</a>
+              <li>código, segmento de   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-12">1.5.2</a>
               </li>
-              <li>columna   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>columna   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>comandos   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>comandos   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>Commons, Creative   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box32">2.5.2</a>
+              <li>Commons, Creative   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-21">2.5.2</a>
               </li>
-              <li>composición   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box24">2.2.3</a>
+              <li>composición   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-13">2.2.3</a>
               </li>
-              <li>compresión de datos con pérdida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box70">4.4.6</a>
+              <li>compresión de datos con pérdida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-26">4.4.6</a>
               </li>
-              <li>compresión de datos sin pérdida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box69">4.4.6</a>
+              <li>compresión de datos sin pérdida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-25">4.4.6</a>
               </li>
-              <li>computación distribuida   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box80">5.1.8</a>
+              <li>computación distribuida   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-10">5.1.8</a>
               </li>
-              <li>computación en paralelo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>computación en paralelo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>computación secuencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>computación secuencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>concatenar   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>concatenar   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>condición   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box15">2.1.2</a>
+              <li>condición   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-4">2.1.2</a>
               </li>
-              <li>condicionales   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box15">2.1.2</a>
+              <li>condicionales   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-4">2.1.2</a>
               </li>
-              <li>conmutación de paquetes   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>conmutación de paquetes   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>constante, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>constante, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>constructor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>constructor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>contradicción, prueba por   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box92">5.4.1</a>
+              <li>contradicción, prueba por   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-22">5.4.1</a>
               </li>
-              <li>correlación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box85">5.3.1</a>
+              <li>correlación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-15">5.3.1</a>
               </li>
-              <li>cortafuego   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>cortafuego   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>Creative Commons   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box32">2.5.2</a>
+              <li>Creative Commons   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-21">2.5.2</a>
               </li>
-              <li>crowdsourcing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>crowdsourcing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
-              <li>cuadrático, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>cuadrático, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="D">D</h2>
             <ol style="list-style-type: square">
-              <li>datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box84">5.3.1</a>
+              <li>datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-14">5.3.1</a>
               </li>
-              <li>datos, abstracción de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>datos, abstracción de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>datos, clasificar los   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box89">5.3.5</a>
+              <li>datos, clasificar los   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-19">5.3.5</a>
               </li>
-              <li>datos, limpieza de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box88">5.3.3</a>
+              <li>datos, limpieza de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-18">5.3.3</a>
               </li>
-              <li>datos, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>datos, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>DDoS, ataque   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>DDoS, ataque   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>decisión, problema de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>decisión, problema de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>denegación de servicio distribuida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>denegación de servicio distribuida   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>depuración   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box3">1.2.3</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box38">3.1.6</a>
+              <li>depuración   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-4">1.2.3</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-5">3.1.6</a>
               </li>
-              <li>descifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box51">4.2.1</a>
+              <li>descifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-7">4.2.1</a>
               </li>
-              <li>digital   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box95">6.1.1</a>
+              <li>digital   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-1">6.1.1</a>
               </li>
-              <li>digital, brecha   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box59">4.3.5</a>
+              <li>digital, brecha   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-15">4.3.5</a>
               </li>
-              <li>dirección IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>dirección IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>disfraces   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box0">1.1.4</a>
+              <li>disfraces   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-1">1.1.4</a>
               </li>
-              <li>dispositivo informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>dispositivo informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>distribuida, computación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box80">5.1.8</a>
+              <li>distribuida, computación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-10">5.1.8</a>
               </li>
-              <li>distribuida, denegación de servicio   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>distribuida, denegación de servicio   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>dominio   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>dominio   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="E">E</h2>
             <ol style="list-style-type: square">
-              <li>eficiencia   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box74">5.1.4</a>
+              <li>eficiencia   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-4">5.1.4</a>
               </li>
-              <li>elemento   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box19">2.2.1</a>
+              <li>elemento   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-8">2.2.1</a>
               </li>
-              <li>enrutador   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box46">4.1.1</a>
+              <li>enrutador   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-2">4.1.1</a>
               </li>
-              <li>enrutamiento   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>enrutamiento   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>entrada   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box40">3.2.2</a>
+              <li>entrada   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-7">3.2.2</a>
               </li>
-              <li>entrada, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>entrada, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>escalabilidad   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>escalabilidad   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>estado, transparencia del   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box101">7.1.1</a>
+              <li>estado, transparencia del   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-2">7.1.1</a>
               </li>
-              <li>exponencial, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>exponencial, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>expresión   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box5">1.2.5</a>
+              <li>expresión   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-6">1.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="F">F</h2>
             <ol style="list-style-type: square">
-              <li>fallas, tolerancia a   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>fallas, tolerancia a   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>flotante, punto   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box67">4.4.4</a>
+              <li>flotante, punto   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-23">4.4.4</a>
               </li>
-              <li>fractal   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box100">7.1.1</a>
+              <li>fractal   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-1">7.1.1</a>
               </li>
-              <li>frecuencia de muestreo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>frecuencia de muestreo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>función de orden superior   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box42">3.2.5</a>
+              <li>función de orden superior   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-9">3.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="G">G</h2>
             <ol style="list-style-type: square">
-              <li>global, variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box16">2.1.4</a>
+              <li>global, variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-5">2.1.4</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="I">I</h2>
             <ol style="list-style-type: square">
-              <li>IA   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>IA   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>identificable, información personal   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box9">1.4.1</a>
+              <li>identificable, información personal   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-10">1.4.1</a>
               </li>
-              <li>indecidible   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box78">5.1.6</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box93">5.4.1</a>
+              <li>indecidible   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-8">5.1.6</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-23">5.4.1</a>
               </li>
-              <li>indecidible, problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>indecidible, problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>índice   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box18">2.1.5</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box29">2.3.5</a>
+              <li>índice   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-7">2.1.5</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-18">2.3.5</a>
               </li>
-              <li>infinito, bucle   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box10">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>infinito, bucle   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-11">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>información   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box84">5.3.1</a>
+              <li>información   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-14">5.3.1</a>
               </li>
-              <li>información personal identificable   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box9">1.4.1</a>
+              <li>información personal identificable   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-10">1.4.1</a>
               </li>
-              <li>informática, innovación   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box61">4.3.6</a>
+              <li>informática, innovación   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-17">4.3.6</a>
               </li>
-              <li>informática, red   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>informática, red   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>informático, dispositivo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>informático, dispositivo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>informático, sistema   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>informático, sistema   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>informático, virus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>informático, virus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>inicializar   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box17">2.1.4</a>
+              <li>inicializar   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-6">2.1.4</a>
               </li>
-              <li>innovación informática   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box61">4.3.6</a>
+              <li>innovación informática   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-17">4.3.6</a>
               </li>
-              <li>insight   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box86">5.3.1</a>
+              <li>insight   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-16">5.3.1</a>
               </li>
-              <li>instancia de un problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>instancia de un problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>integrado, circuito   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box98">6.1.8</a>
+              <li>integrado, circuito   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-4">6.1.8</a>
               </li>
-              <li>inteligencia artificial (IA)   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>inteligencia artificial (IA)   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>interfaz de programa de aplicación   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box31">2.4.2</a>
+              <li>interfaz de programa de aplicación   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-20">2.4.2</a>
               </li>
-              <li>internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>internet, proveedores de servicios de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box46">4.1.1</a>
+              <li>internet, proveedores de servicios de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-2">4.1.1</a>
               </li>
-              <li>IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>IP, dirección   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>IP, dirección   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>irresoluble, problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>irresoluble, problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>iteración   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box8">1.3.6</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>iteración   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-9">1.3.6</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="L">L</h2>
             <ol style="list-style-type: square">
-              <li>lenguaje de máquina   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box97">6.1.6</a>
+              <li>lenguaje de máquina   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>ley de moore   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box99">6.2.2</a>
+              <li>ley de moore   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-5">6.2.2</a>
               </li>
-              <li>libre, software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>libre, software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>limpieza de datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box88">5.3.3</a>
+              <li>limpieza de datos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-18">5.3.3</a>
               </li>
-              <li>lineal, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>lineal, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>lineal, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>lineal, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>lista   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>lista   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>local, variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box13">2.1.1</a>
+              <li>local, variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-2">2.1.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="M">M</h2>
             <ol style="list-style-type: square">
-              <li>malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>máquina, lenguaje de   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box97">6.1.6</a>
+              <li>máquina, lenguaje de   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>metadatos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box91">5.3.6</a>
+              <li>metadatos   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-21">5.3.6</a>
               </li>
-              <li>modo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box90">5.3.5</a>
+              <li>modo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-20">5.3.5</a>
               </li>
-              <li>modularidad   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box36">3.1.4</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box41">3.2.4</a>
+              <li>modularidad   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-3">3.1.4</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-8">3.2.4</a>
               </li>
-              <li>moore, ley de   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box99">6.2.2</a>
+              <li>moore, ley de   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-5">6.2.2</a>
               </li>
-              <li>muestras   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>muestras   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>muestreo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>muestreo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>muestreo, frecuencia de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>muestreo, frecuencia de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="N">N</h2>
             <ol style="list-style-type: square">
-              <li>nube   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>nube   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="O">O</h2>
             <ol style="list-style-type: square">
-              <li>objeto   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box0">1.1.4</a>
+              <li>objeto   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-1">1.1.4</a>
               </li>
-              <li>objeto, variable del   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box43">3.3.1</a>
+              <li>objeto, variable del   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-10">3.3.1</a>
               </li>
-              <li>optimización, problema de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>optimización, problema de   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="P">P</h2>
             <ol style="list-style-type: square">
-              <li>palabra   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box63">4.4.1</a>, <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box66">4.4.3</a>
+              <li>palabra   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-19">4.4.1</a>, <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-22">4.4.3</a>
               </li>
-              <li>paquete   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>paquete   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>paquetes, conmutación de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>paquetes, conmutación de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>paralelo, computación en   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>paralelo, computación en   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>parámetro   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box7">1.3.3</a>
+              <li>parámetro   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-8">1.3.3</a>
               </li>
-              <li>pérdida, compresión de datos con   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box70">4.4.6</a>
+              <li>pérdida, compresión de datos con   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-26">4.4.6</a>
               </li>
-              <li>pérdida, compresión de datos sin   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box69">4.4.6</a>
+              <li>pérdida, compresión de datos sin   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-25">4.4.6</a>
               </li>
-              <li>phishing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>phishing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>polinómico, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>polinómico, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>predicado   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>predicado   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>primitivos, tipos de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>primitivos, tipos de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>problema   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>problema de decisión   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>problema de decisión   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>problema de optimización   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>problema de optimización   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>problema indecidible   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>problema indecidible   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>problema irresoluble   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>problema irresoluble   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>problema, instancia de un   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>problema, instancia de un   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>procedimiento   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>procedimiento   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>procesador   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box81">5.1.8</a>
+              <li>procesador   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-11">5.1.8</a>
               </li>
-              <li>procesal, abstracción   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box35">3.1.4</a>
+              <li>procesal, abstracción   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-2">3.1.4</a>
               </li>
-              <li>protocolo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>protocolo   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>proveedores de servicios de internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box46">4.1.1</a>
+              <li>proveedores de servicios de internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-2">4.1.1</a>
               </li>
-              <li>prueba por contradicción   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box92">5.4.1</a>
+              <li>prueba por contradicción   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-22">5.4.1</a>
               </li>
-              <li>pseudocódigo   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box6">1.3.1</a>
+              <li>pseudocódigo   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-7">1.3.1</a>
               </li>
-              <li>pública, cifrado de clave   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box53">4.2.3</a>
+              <li>pública, cifrado de clave   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-9">4.2.3</a>
               </li>
-              <li>punto de acceso no autorizado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box58">4.2.5</a>
+              <li>punto de acceso no autorizado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-14">4.2.5</a>
               </li>
-              <li>punto flotante   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box67">4.4.4</a>
+              <li>punto flotante   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-23">4.4.4</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="R">R</h2>
             <ol style="list-style-type: square">
-              <li>rango   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>rango   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>recorrer   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box25">2.2.3</a>
+              <li>recorrer   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-14">2.2.3</a>
               </li>
-              <li>recursión   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box34">3.1.3</a>
+              <li>recursión   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-1">3.1.3</a>
               </li>
-              <li>recursividad   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box102">7.1.1</a>
+              <li>recursividad   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-3">7.1.1</a>
               </li>
-              <li>red informática   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>red informática   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>redundancia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>redundancia   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>registro   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>registro   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>reporteros   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>reporteros   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>resoluble   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box78">5.1.6</a>
+              <li>resoluble   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-8">5.1.6</a>
               </li>
-              <li>ruta   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>ruta   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="S">S</h2>
             <ol style="list-style-type: square">
-              <li>salida   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box40">3.2.2</a>
+              <li>salida   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-7">3.2.2</a>
               </li>
-              <li>salida, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>salida, tipo de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>secuencia binaria   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box64">4.4.2</a>
+              <li>secuencia binaria   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-20">4.4.2</a>
               </li>
-              <li>secuenciación   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>secuenciación   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
-              <li>secuencial, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>secuencial, búsqueda   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>secuencial, computación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>secuencial, computación   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>segmento de código   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box11">1.5.2</a>
+              <li>segmento de código   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-12">1.5.2</a>
               </li>
-              <li>selección   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>selección   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
-              <li>selectores   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>selectores   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>sentencia condicional anidada   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box28">2.3.3</a>
+              <li>sentencia condicional anidada   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-17">2.3.3</a>
               </li>
-              <li>simétrico, cifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box52">4.2.1</a>
+              <li>simétrico, cifrado   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-8">4.2.1</a>
               </li>
-              <li>simulaciones   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box83">5.2.1</a>
+              <li>simulaciones   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-13">5.2.1</a>
               </li>
-              <li>sistema informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>sistema informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>software antivirus o antimalware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software antivirus o antimalware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>software de registro de teclas   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software de registro de teclas   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>software libre   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>software libre   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>software, biblioteca de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box30">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#box96">6.1.4</a>
+              <li>software, biblioteca de   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-19">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.es.html?topic=nyc_bjc/6-how-computers-work.es.topic&amp;course=bjc4nyc.html#vocab-2">6.1.4</a>
               </li>
-              <li>SSL/TLS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box54">4.2.3</a>
+              <li>SSL/TLS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-10">4.2.3</a>
               </li>
-              <li>sub-cadena   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>sub-cadena   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>subconjunto   <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-vocab.es.html?topic=nyc_bjc/8-recursive-reporters.es.topic&amp;course=bjc4nyc.html#box104">8.3.1</a>
+              <li>subconjunto   <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-vocab.es.html?topic=nyc_bjc/8-recursive-reporters.es.topic&amp;course=bjc4nyc.html#vocab-1">8.3.1</a>
               </li>
-              <li>sublineal, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>sublineal, tiempo   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>sublista   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box20">2.2.2</a>
+              <li>sublista   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-9">2.2.2</a>
               </li>
-              <li>superior, función de orden   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box42">3.2.5</a>
+              <li>superior, función de orden   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-9">3.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="T">T</h2>
             <ol style="list-style-type: square">
-              <li>tabla   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box23">2.2.2</a>
+              <li>tabla   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-12">2.2.2</a>
               </li>
-              <li>TCP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>TCP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>TCP/IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>TCP/IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>teclas, software de registro de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>teclas, software de registro de   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>tiempo constante   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>tiempo constante   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>tiempo cuadrático   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>tiempo cuadrático   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>tiempo exponencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>tiempo exponencial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>tiempo lineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>tiempo lineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>tiempo polinómico   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>tiempo polinómico   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>tiempo sublineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>tiempo sublineal   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.es.html?topic=nyc_bjc/5-algorithms.es.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>tipo de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>tipo de datos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>tipo de datos abstracto   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box39">3.2.1</a>
+              <li>tipo de datos abstracto   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-6">3.2.1</a>
               </li>
-              <li>tipo de datos abstractos (ADT)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>tipo de datos abstractos (ADT)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>tipo de entrada   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>tipo de entrada   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>tipo de salida   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>tipo de salida   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>tipos de datos primitivos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>tipos de datos primitivos   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>tolerancia a fallas   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>tolerancia a fallas   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>transparencia   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box1">1.1.4</a>
+              <li>transparencia   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-2">1.1.4</a>
               </li>
-              <li>transparencia del estado   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#box101">7.1.1</a>
+              <li>transparencia del estado   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.es.html?topic=nyc_bjc/7-recursion-trees-fractals.es.topic&amp;course=bjc4nyc.html#vocab-2">7.1.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="V">V</h2>
             <ol style="list-style-type: square">
-              <li>valor   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#box5">1.2.5</a>
+              <li>valor   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.es.html?topic=nyc_bjc/1-intro-loops.es.topic&amp;course=bjc4nyc.html#vocab-6">1.2.5</a>
               </li>
-              <li>valor booleano   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>valor booleano   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box12">2.1.1</a>
+              <li>variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-1">2.1.1</a>
               </li>
-              <li>variable del objeto   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#box43">3.3.1</a>
+              <li>variable del objeto   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.es.html?topic=nyc_bjc/3-lists.es.topic&amp;course=bjc4nyc.html#vocab-10">3.3.1</a>
               </li>
-              <li>variable global   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box16">2.1.4</a>
+              <li>variable global   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-5">2.1.4</a>
               </li>
-              <li>variable local   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#box13">2.1.1</a>
+              <li>variable local   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.es.html?topic=nyc_bjc/2-conditionals-abstraction.es.topic&amp;course=bjc4nyc.html#vocab-2">2.1.1</a>
               </li>
-              <li>virus informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>virus informático   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="W">W</h2>
             <ol style="list-style-type: square">
-              <li>web, world wide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>web, world wide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>world wide web   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>world wide web   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.es.html?topic=nyc_bjc/4-internet.es.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
             </ol>
           </li>

--- a/cur/programming/vocab-index.html
+++ b/cur/programming/vocab-index.html
@@ -43,600 +43,600 @@
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="A">A</h2>
             <ol style="list-style-type: square">
-              <li>abstract data type (ADT)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box39">3.2.1</a>
+              <li>abstract data type (ADT)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-6">3.2.1</a>
               </li>
-              <li>abstraction, data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>abstraction, data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>abstraction, procedural   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box35">3.1.4</a>
+              <li>abstraction, procedural   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-2">3.1.4</a>
               </li>
-              <li>access, open   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>access, open   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>address, IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>address, IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>ADT   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box39">3.2.1</a>
+              <li>ADT   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-6">3.2.1</a>
               </li>
-              <li>AI   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>AI   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>algorithm   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box6">1.3.1</a>
+              <li>algorithm   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-7">1.3.1</a>
               </li>
-              <li>analog   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box97">6.1.1</a>
+              <li>analog   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-1">6.1.1</a>
               </li>
-              <li>anti-malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>anti-malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>antivirus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>antivirus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>antivirus or anti-malware software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>antivirus or anti-malware software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>API   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box31">2.4.2</a>
+              <li>API   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-20">2.4.2</a>
               </li>
-              <li>application program interface (API)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box31">2.4.2</a>
+              <li>application program interface (API)   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-20">2.4.2</a>
               </li>
-              <li>architecture   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box99">6.1.6</a>
+              <li>architecture   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>argument   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box7">1.3.3</a>
+              <li>argument   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-8">1.3.3</a>
               </li>
-              <li>artificial intelligence (AI)   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>artificial intelligence (AI)   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>attack, DDoS (Distributed Denial of Service)   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>attack, DDoS (Distributed Denial of Service)   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>authorities, certificate   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box55">4.2.3</a>
+              <li>authorities, certificate   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-11">4.2.3</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="B">B</h2>
             <ol style="list-style-type: square">
-              <li>bandwidth   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>bandwidth   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
-              <li>base case   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box105">7.1.2</a>
+              <li>base case   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-4">7.1.2</a>
               </li>
-              <li>binary search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box73">5.1.3</a>
+              <li>binary search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-3">5.1.3</a>
               </li>
-              <li>binary sequence   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box64">4.4.2</a>
+              <li>binary sequence   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-20">4.4.2</a>
               </li>
-              <li>bit   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box62">4.4.1</a>
+              <li>bit   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-18">4.4.1</a>
               </li>
-              <li>Boolean value   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>Boolean value   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>byte   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box63">4.4.1</a>
+              <li>byte   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-19">4.4.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="C">C</h2>
             <ol style="list-style-type: square">
-              <li>case, base   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box105">7.1.2</a>
+              <li>case, base   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-4">7.1.2</a>
               </li>
-              <li>certificate authorities   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box55">4.2.3</a>
+              <li>certificate authorities   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-11">4.2.3</a>
               </li>
-              <li>circuit, integrated   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box100">6.1.8</a>
+              <li>circuit, integrated   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-4">6.1.8</a>
               </li>
-              <li>citizen science   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>citizen science   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
-              <li>classifying data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box89">5.3.5</a>
+              <li>classifying data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-19">5.3.5</a>
               </li>
-              <li>cleaning data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box88">5.3.3</a>
+              <li>cleaning data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-18">5.3.3</a>
               </li>
-              <li>clone   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box37">3.1.5</a>
+              <li>clone   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-4">3.1.5</a>
               </li>
-              <li>cloud, the   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>cloud, the   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
-              <li>code segment   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box11">1.5.2</a>
+              <li>code segment   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-12">1.5.2</a>
               </li>
-              <li>column   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>column   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>commands   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>commands   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>Commons, Creative   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box32">2.5.2</a>
+              <li>Commons, Creative   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-21">2.5.2</a>
               </li>
-              <li>composition   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box24">2.2.3</a>
+              <li>composition   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-13">2.2.3</a>
               </li>
-              <li>computer network   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>computer network   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>computer virus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>computer virus   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>computing device   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>computing device   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>computing innovation   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box61">4.3.6</a>
+              <li>computing innovation   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-17">4.3.6</a>
               </li>
-              <li>computing system   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>computing system   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>computing, distributed   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box80">5.1.8</a>
+              <li>computing, distributed   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-10">5.1.8</a>
               </li>
-              <li>computing, parallel   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>computing, parallel   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>computing, sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>computing, sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>concatenate   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>concatenate   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>condition   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box15">2.1.2</a>
+              <li>condition   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-4">2.1.2</a>
               </li>
-              <li>conditionals   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box15">2.1.2</a>
+              <li>conditionals   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-4">2.1.2</a>
               </li>
-              <li>constant time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>constant time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>constructor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>constructor   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>contradiction, proof by   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box92">5.4.1</a>
+              <li>contradiction, proof by   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-22">5.4.1</a>
               </li>
-              <li>correlation   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box85">5.3.1</a>
+              <li>correlation   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-15">5.3.1</a>
               </li>
-              <li>costumes   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box0">1.1.4</a>
+              <li>costumes   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-1">1.1.4</a>
               </li>
-              <li>Creative Commons   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box32">2.5.2</a>
+              <li>Creative Commons   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-21">2.5.2</a>
               </li>
-              <li>crowdsourcing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>crowdsourcing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="D">D</h2>
             <ol style="list-style-type: square">
-              <li>data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box84">5.3.1</a>
+              <li>data   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-14">5.3.1</a>
               </li>
-              <li>data abstraction   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>data abstraction   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>data compression, lossless   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box69">4.4.6</a>
+              <li>data compression, lossless   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-25">4.4.6</a>
               </li>
-              <li>data compression, lossy   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box70">4.4.6</a>
+              <li>data compression, lossy   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-26">4.4.6</a>
               </li>
-              <li>data type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>data type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>data, classifying   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box89">5.3.5</a>
+              <li>data, classifying   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-19">5.3.5</a>
               </li>
-              <li>data, cleaning   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box88">5.3.3</a>
+              <li>data, cleaning   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-18">5.3.3</a>
               </li>
-              <li>DDoS (Distributed Denial of Service) attack   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box57">4.2.5</a>
+              <li>DDoS (Distributed Denial of Service) attack   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-13">4.2.5</a>
               </li>
-              <li>debugging   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box3">1.2.3</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box38">3.1.6</a>
+              <li>debugging   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-4">1.2.3</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-5">3.1.6</a>
               </li>
-              <li>decidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box78">5.1.6</a>
+              <li>decidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-8">5.1.6</a>
               </li>
-              <li>decision problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>decision problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>decryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box51">4.2.1</a>
+              <li>decryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-7">4.2.1</a>
               </li>
-              <li>device, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>device, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>digital   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box97">6.1.1</a>
+              <li>digital   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-1">6.1.1</a>
               </li>
-              <li>digital divide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box59">4.3.5</a>
+              <li>digital divide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-15">4.3.5</a>
               </li>
-              <li>distributed computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box80">5.1.8</a>
+              <li>distributed computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-10">5.1.8</a>
               </li>
-              <li>divide, digital   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box59">4.3.5</a>
+              <li>divide, digital   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-15">4.3.5</a>
               </li>
-              <li>domain   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>domain   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="E">E</h2>
             <ol style="list-style-type: square">
-              <li>efficiency   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box74">5.1.4</a>
+              <li>efficiency   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-4">5.1.4</a>
               </li>
-              <li>element   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box19">2.2.1</a>
+              <li>element   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-8">2.2.1</a>
               </li>
-              <li>encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box51">4.2.1</a>
+              <li>encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-7">4.2.1</a>
               </li>
-              <li>encryption, public key   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box53">4.2.3</a>
+              <li>encryption, public key   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-9">4.2.3</a>
               </li>
-              <li>encryption, symmetric   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box52">4.2.1</a>
+              <li>encryption, symmetric   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-8">4.2.1</a>
               </li>
-              <li>exponential time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>exponential time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>expression   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box5">1.2.5</a>
+              <li>expression   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-6">1.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="F">F</h2>
             <ol style="list-style-type: square">
-              <li>fault tolerance   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>fault tolerance   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>field   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>field   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>firewall   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>firewall   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>floating point   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box67">4.4.4</a>
+              <li>floating point   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-23">4.4.4</a>
               </li>
-              <li>fractal   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box102">7.1.1</a>
+              <li>fractal   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-1">7.1.1</a>
               </li>
-              <li>free software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>free software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>function, higher-order   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box42">3.2.5</a>
+              <li>function, higher-order   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-9">3.2.5</a>
               </li>
-              <li>functional   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box95">5.7.1</a>
+              <li>functional   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-25">5.7.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="G">G</h2>
             <ol style="list-style-type: square">
-              <li>global variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box16">2.1.4</a>
+              <li>global variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-5">2.1.4</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="H">H</h2>
             <ol style="list-style-type: square">
-              <li>higher-order function   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box42">3.2.5</a>
+              <li>higher-order function   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-9">3.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="I">I</h2>
             <ol style="list-style-type: square">
-              <li>index   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box18">2.1.5</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box29">2.3.5</a>
+              <li>index   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-7">2.1.5</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-18">2.3.5</a>
               </li>
-              <li>infinite loop   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box10">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>infinite loop   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-11">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>information   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box84">5.3.1</a>
+              <li>information   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-14">5.3.1</a>
               </li>
-              <li>information, personally identifiable   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box9">1.4.1</a>
+              <li>information, personally identifiable   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-10">1.4.1</a>
               </li>
-              <li>initializing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box17">2.1.4</a>
+              <li>initializing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-6">2.1.4</a>
               </li>
-              <li>innovation, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box61">4.3.6</a>
+              <li>innovation, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-17">4.3.6</a>
               </li>
-              <li>input   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box40">3.2.2</a>
+              <li>input   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-7">3.2.2</a>
               </li>
-              <li>input type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>input type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>insight   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box86">5.3.1</a>
+              <li>insight   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-16">5.3.1</a>
               </li>
-              <li>instance of a problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>instance of a problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>integrated circuit   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box100">6.1.8</a>
+              <li>integrated circuit   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-4">6.1.8</a>
               </li>
-              <li>intelligence, artificial   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box44">3.4.1</a>
+              <li>intelligence, artificial   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-11">3.4.1</a>
               </li>
-              <li>interface, application program   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box31">2.4.2</a>
+              <li>interface, application program   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-20">2.4.2</a>
               </li>
-              <li>internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>internet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>IP address   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>IP address   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>ISPs   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box46">4.1.1</a>
+              <li>ISPs   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-2">4.1.1</a>
               </li>
-              <li>iteration   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box8">1.3.6</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>iteration   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-9">1.3.6</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="K">K</h2>
             <ol style="list-style-type: square">
-              <li>keylogging software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>keylogging software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="L">L</h2>
             <ol style="list-style-type: square">
-              <li>language, machine   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box99">6.1.6</a>
+              <li>language, machine   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>law, moore's   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box101">6.2.2</a>
+              <li>law, moore's   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-5">6.2.2</a>
               </li>
-              <li>library, software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box30">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box98">6.1.4</a>
+              <li>library, software   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-19">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-2">6.1.4</a>
               </li>
-              <li>linear search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>linear search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>linear time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>linear time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>list   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>list   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>local variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box13">2.1.1</a>
+              <li>local variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-2">2.1.1</a>
               </li>
-              <li>loop, infinite   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box10">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>loop, infinite   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-11">1.5.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>lossless data compression   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box69">4.4.6</a>
+              <li>lossless data compression   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-25">4.4.6</a>
               </li>
-              <li>lossy data compression   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box70">4.4.6</a>
+              <li>lossy data compression   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-26">4.4.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="M">M</h2>
             <ol style="list-style-type: square">
-              <li>machine language   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box99">6.1.6</a>
+              <li>machine language   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-3">6.1.6</a>
               </li>
-              <li>malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>metadata   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box91">5.3.6</a>
+              <li>metadata   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-21">5.3.6</a>
               </li>
-              <li>mode   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box90">5.3.5</a>
+              <li>mode   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-20">5.3.5</a>
               </li>
-              <li>modularity   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box36">3.1.4</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box41">3.2.4</a>
+              <li>modularity   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-3">3.1.4</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-8">3.2.4</a>
               </li>
-              <li>moore's law   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box101">6.2.2</a>
+              <li>moore's law   <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-5">6.2.2</a>
               </li>
-              <li>multi-paradigm   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box95">5.7.1</a>
+              <li>multi-paradigm   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-25">5.7.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="N">N</h2>
             <ol style="list-style-type: square">
-              <li>nested conditional statement   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box28">2.3.3</a>
+              <li>nested conditional statement   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-17">2.3.3</a>
               </li>
-              <li>network, computer   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>network, computer   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="O">O</h2>
             <ol style="list-style-type: square">
-              <li>object-oriented   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box95">5.7.1</a>
+              <li>object-oriented   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-25">5.7.1</a>
               </li>
-              <li>open access   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>open access   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>open source   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>open source   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>optimization problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>optimization problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>output   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box40">3.2.2</a>
+              <li>output   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-7">3.2.2</a>
               </li>
-              <li>output type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>output type   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="P">P</h2>
             <ol style="list-style-type: square">
-              <li>packet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>packet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>packet switching   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>packet switching   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>parallel computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>parallel computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>parameter   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box7">1.3.3</a>
+              <li>parameter   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-8">1.3.3</a>
               </li>
-              <li>path   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>path   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>personally identifiable information (PII)   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box9">1.4.1</a>
+              <li>personally identifiable information (PII)   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-10">1.4.1</a>
               </li>
-              <li>phishing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>phishing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>PII   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box9">1.4.1</a>
+              <li>PII   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-10">1.4.1</a>
               </li>
-              <li>point, floating   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box67">4.4.4</a>
+              <li>point, floating   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-23">4.4.4</a>
               </li>
-              <li>point, rogue access   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box58">4.2.5</a>
+              <li>point, rogue access   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-14">4.2.5</a>
               </li>
-              <li>polynomial time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>polynomial time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>predicate   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>predicate   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>primitive data types   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>primitive data types   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>problem, decision   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>problem, decision   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>problem, instance of a   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box71">5.1.2</a>
+              <li>problem, instance of a   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-1">5.1.2</a>
               </li>
-              <li>problem, optimization   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box77">5.1.6</a>
+              <li>problem, optimization   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-7">5.1.6</a>
               </li>
-              <li>problem, undecidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>problem, undecidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>problem, unsolvable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>problem, unsolvable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>procedural abstraction   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box35">3.1.4</a>
+              <li>procedural abstraction   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-2">3.1.4</a>
               </li>
-              <li>procedure   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>procedure   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>processor   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box81">5.1.8</a>
+              <li>processor   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-11">5.1.8</a>
               </li>
-              <li>proof by contradiction   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box92">5.4.1</a>
+              <li>proof by contradiction   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-22">5.4.1</a>
               </li>
-              <li>protocol   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>protocol   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>pseudocode   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box6">1.3.1</a>
+              <li>pseudocode   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-7">1.3.1</a>
               </li>
-              <li>public key encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box53">4.2.3</a>
+              <li>public key encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-9">4.2.3</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="Q">Q</h2>
             <ol style="list-style-type: square">
-              <li>quadratic time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>quadratic time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="R">R</h2>
             <ol style="list-style-type: square">
-              <li>range   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>range   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>rate, sampling   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>rate, sampling   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>record   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box87">5.3.3</a>
+              <li>record   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-17">5.3.3</a>
               </li>
-              <li>recursion   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box34">3.1.3</a>, <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box104">7.1.1</a>
+              <li>recursion   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-1">3.1.3</a>, <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-3">7.1.1</a>
               </li>
-              <li>redundancy   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>redundancy   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>reporters   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box4">1.2.4</a>
+              <li>reporters   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-5">1.2.4</a>
               </li>
-              <li>rogue access point   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box58">4.2.5</a>
+              <li>rogue access point   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-14">4.2.5</a>
               </li>
-              <li>router   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box46">4.1.1</a>
+              <li>router   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-2">4.1.1</a>
               </li>
-              <li>routing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>routing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="S">S</h2>
             <ol style="list-style-type: square">
-              <li>samples   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>samples   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>sampling   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>sampling   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>sampling rate   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box65">4.4.2</a>
+              <li>sampling rate   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-21">4.4.2</a>
               </li>
-              <li>scalability   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>scalability   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>science, citizen   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box60">4.3.6</a>
+              <li>science, citizen   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-16">4.3.6</a>
               </li>
-              <li>search, binary   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box73">5.1.3</a>
+              <li>search, binary   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-3">5.1.3</a>
               </li>
-              <li>search, linear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>search, linear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>search, sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>search, sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>segment, code   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box11">1.5.2</a>
+              <li>segment, code   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-12">1.5.2</a>
               </li>
-              <li>selection   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>selection   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
-              <li>selectors   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>
+              <li>selectors   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>
               </li>
-              <li>self-contradictory   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box93">5.4.1</a>
+              <li>self-contradictory   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-23">5.4.1</a>
               </li>
-              <li>semantics   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box96">5.7.1</a>
+              <li>semantics   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-26">5.7.1</a>
               </li>
-              <li>sequence, binary   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box64">4.4.2</a>
+              <li>sequence, binary   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-20">4.4.2</a>
               </li>
-              <li>sequencing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box27">2.3.1</a>
+              <li>sequencing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-16">2.3.1</a>
               </li>
-              <li>sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box95">5.7.1</a>
+              <li>sequential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-25">5.7.1</a>
               </li>
-              <li>sequential computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box79">5.1.8</a>
+              <li>sequential computing   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-9">5.1.8</a>
               </li>
-              <li>sequential search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>
+              <li>sequential search   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>
               </li>
-              <li>simulations   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box83">5.2.1</a>
+              <li>simulations   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-13">5.2.1</a>
               </li>
-              <li>software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>software library   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box30">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#box98">6.1.4</a>
+              <li>software library   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-19">2.4.2</a>, <a href="/bjc-r/cur/programming/6-computers/unit-6-vocab.html?topic=nyc_bjc/6-how-computers-work.topic&amp;course=bjc4nyc.html#vocab-2">6.1.4</a>
               </li>
-              <li>software, antivirus or anti-malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software, antivirus or anti-malware   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>software, free   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>software, free   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>software, keylogging   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>software, keylogging   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
-              <li>source, open   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box33">2.5.2</a>
+              <li>source, open   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-22">2.5.2</a>
               </li>
-              <li>speedup   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box82">5.1.8</a>
+              <li>speedup   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-12">5.1.8</a>
               </li>
-              <li>sprite   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box0">1.1.4</a>
+              <li>sprite   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-1">1.1.4</a>
               </li>
-              <li>sprite variable   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box43">3.3.1</a>
+              <li>sprite variable   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-10">3.3.1</a>
               </li>
-              <li>SSL/TLS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box54">4.2.3</a>
+              <li>SSL/TLS   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-10">4.2.3</a>
               </li>
-              <li>state transparency   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box103">7.1.1</a>
+              <li>state transparency   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-2">7.1.1</a>
               </li>
-              <li>statement, nested conditional   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box28">2.3.3</a>
+              <li>statement, nested conditional   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-17">2.3.3</a>
               </li>
-              <li>string   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box29">2.3.5</a>
+              <li>string   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>, <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-18">2.3.5</a>
               </li>
-              <li>sublinear time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>sublinear time   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>sublist   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box20">2.2.2</a>
+              <li>sublist   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-9">2.2.2</a>
               </li>
-              <li>subset   <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-vocab.html?topic=nyc_bjc/8-recursive-reporters.topic&amp;course=bjc4nyc.html#box106">8.3.1</a>
+              <li>subset   <a href="/bjc-r/cur/programming/8-recursive-reporters/unit-8-vocab.html?topic=nyc_bjc/8-recursive-reporters.topic&amp;course=bjc4nyc.html#vocab-1">8.3.1</a>
               </li>
-              <li>substring   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box2">1.2.3</a>
+              <li>substring   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-3">1.2.3</a>
               </li>
-              <li>switching, packet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box49">4.1.3</a>
+              <li>switching, packet   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-5">4.1.3</a>
               </li>
-              <li>symmetric encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box52">4.2.1</a>
+              <li>symmetric encryption   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-8">4.2.1</a>
               </li>
-              <li>syntax   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box96">5.7.1</a>
+              <li>syntax   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-26">5.7.1</a>
               </li>
-              <li>system, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>system, computing   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="T">T</h2>
             <ol style="list-style-type: square">
-              <li>table   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box23">2.2.2</a>
+              <li>table   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-12">2.2.2</a>
               </li>
-              <li>TCP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>TCP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>TCP/IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box50">4.1.3</a>
+              <li>TCP/IP   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-6">4.1.3</a>
               </li>
-              <li>the cloud   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box47">4.1.1</a>
+              <li>the cloud   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-3">4.1.1</a>
               </li>
-              <li>time, constant   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>time, constant   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>time, exponential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>time, exponential   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>time, linear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box72">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>time, linear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-2">5.1.2</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>time, polynomial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box76">5.1.5</a>
+              <li>time, polynomial   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-6">5.1.5</a>
               </li>
-              <li>time, quadratic   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>time, quadratic   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>time, sublinear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box75">5.1.5</a>
+              <li>time, sublinear   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-5">5.1.5</a>
               </li>
-              <li>tolerance, fault   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box48">4.1.2</a>
+              <li>tolerance, fault   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-4">4.1.2</a>
               </li>
-              <li>transparency   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box1">1.1.4</a>
+              <li>transparency   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-2">1.1.4</a>
               </li>
-              <li>transparency, state   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#box103">7.1.1</a>
+              <li>transparency, state   <a href="/bjc-r/cur/programming/7-recursion/unit-7-vocab.html?topic=nyc_bjc/7-recursion-trees-fractals.topic&amp;course=bjc4nyc.html#vocab-2">7.1.1</a>
               </li>
-              <li>traversing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box25">2.2.3</a>
+              <li>traversing   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-14">2.2.3</a>
               </li>
-              <li>type, abstract data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box22">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box39">3.2.1</a>
+              <li>type, abstract data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-11">2.2.2</a>, <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-6">3.2.1</a>
               </li>
-              <li>type, data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>type, data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
-              <li>type, input   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>type, input   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>type, output   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box26">2.3.1</a>
+              <li>type, output   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-15">2.3.1</a>
               </li>
-              <li>types, primitive data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box21">2.2.2</a>
+              <li>types, primitive data   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-10">2.2.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="U">U</h2>
             <ol style="list-style-type: square">
-              <li>undecidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box78">5.1.6</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box93">5.4.1</a>
+              <li>undecidable   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-8">5.1.6</a>, <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-23">5.4.1</a>
               </li>
-              <li>undecidable problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>undecidable problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
-              <li>unsolvable problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#box94">5.4.2</a>
+              <li>unsolvable problem   <a href="/bjc-r/cur/programming/5-algorithms/unit-5-vocab.html?topic=nyc_bjc/5-algorithms.topic&amp;course=bjc4nyc.html#vocab-24">5.4.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="V">V</h2>
             <ol style="list-style-type: square">
-              <li>value   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#box5">1.2.5</a>
+              <li>value   <a href="/bjc-r/cur/programming/1-introduction/unit-1-vocab.html?topic=nyc_bjc/1-intro-loops.topic&amp;course=bjc4nyc.html#vocab-6">1.2.5</a>
               </li>
-              <li>value, Boolean   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box14">2.1.2</a>
+              <li>value, Boolean   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-3">2.1.2</a>
               </li>
-              <li>variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box12">2.1.1</a>
+              <li>variable   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-1">2.1.1</a>
               </li>
-              <li>variable, global   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box16">2.1.4</a>
+              <li>variable, global   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-5">2.1.4</a>
               </li>
-              <li>variable, local   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#box13">2.1.1</a>
+              <li>variable, local   <a href="/bjc-r/cur/programming/2-complexity/unit-2-vocab.html?topic=nyc_bjc/2-conditionals-abstraction.topic&amp;course=bjc4nyc.html#vocab-2">2.1.1</a>
               </li>
-              <li>variable, sprite   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#box43">3.3.1</a>
+              <li>variable, sprite   <a href="/bjc-r/cur/programming/3-lists/unit-3-vocab.html?topic=nyc_bjc/3-lists.topic&amp;course=bjc4nyc.html#vocab-10">3.3.1</a>
               </li>
-              <li>virus, computer   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box56">4.2.5</a>
+              <li>virus, computer   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-12">4.2.5</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="W">W</h2>
             <ol style="list-style-type: square">
-              <li>web, world wide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>web, world wide   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
-              <li>width   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box66">4.4.3</a>
+              <li>width   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-22">4.4.3</a>
               </li>
-              <li>word   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box63">4.4.1</a>, <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box66">4.4.3</a>
+              <li>word   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-19">4.4.1</a>, <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-22">4.4.3</a>
               </li>
-              <li>world wide web   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#box45">4.1.1</a>
+              <li>world wide web   <a href="/bjc-r/cur/programming/4-internet/unit-4-vocab.html?topic=nyc_bjc/4-internet.topic&amp;course=bjc4nyc.html#vocab-1">4.1.1</a>
               </li>
             </ol>
           </li>

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -43,10 +43,23 @@ body {
   padding: 50px 1em 1em; /* padding top is reset by JS on load. */
 }
 
-:target {
+/* .anchor-target is every box llab.addContentAnchors numbered. Its ID is
+ * assigned after the page loads, so :target never matches it -- without the
+ * rule here the box would land behind the navbar. */
+:target,
+.anchor-target {
   /* Offset for in-page links because of fixed nav bar */
   /* Larger value than nav for extra roominess */
   scroll-margin-top: 140px !important;
+}
+
+/* An anchor target is focused when scrolled to, so the next Tab continues
+ * from there. It is a destination rather than a control, and a ring around a
+ * whole box reads as a selection, so draw none -- same reasoning as
+ * #main-content:focus below. :focus-visible would not help: focus arriving
+ * from a link counts as visible. */
+.anchor-target:focus {
+  outline: none;
 }
 
 code, pre, tt, kbd, samp, var {

--- a/llab/script/curriculum.js
+++ b/llab/script/curriculum.js
@@ -23,6 +23,18 @@ const TOGGLE_HEADINGS = [
   'takeItTeased',
 ];
 
+// Content boxes that a URL can name with a #fragment, and that the generated
+// summary pages link back to. Each selector must collect exactly what its
+// counterpart in utilities/build-tools/ collects -- vocab.rb's VOCAB_CLASSES
+// and selfcheck.rb's examFullWidth -- because a generated link identifies a
+// box only by its position on the page.
+// Self-check questions are missing here on purpose: quiz.js replaces their
+// source markup with a rendered question, so multiplechoice.js numbers them.
+const CONTENT_ANCHORS = [
+  { type: 'vocab', selector: 'div[class*="vocab"]' },
+  { type: 'exam', selector: 'div[class*="examFullWidth"]' },
+];
+
 // THE switch for dynamic (SPA-style) page loads. This is the only global
 // which controls the feature. When false, navigation links behave like
 // normal links and browser history is never touched.
@@ -79,6 +91,67 @@ window.addEventListener("pageshow", (event) => {
   llab.setupTranslationsMenu();
 });
 
+///////////////////// CONTENT ANCHORS
+
+// The ID of the NUMBERth box of TYPE on a page, counting from 1.
+// The build tools spell the same IDs out in BJCHelpers#anchor_id; the two
+// must agree, since that is all a generated link has to go on.
+llab.anchorID = (type, number) => `${type}-${number}`;
+
+// Give ELEMENT the ID that in-page links use to reach it. The tabindex lets
+// llab.scrollToAnchor move keyboard focus onto what is otherwise a plain
+// <div>; -1 keeps it out of the tab order. See .anchor-target in default.css.
+llab.markAnchorTarget = (element, id) => {
+  element.id = id;
+  element.classList.add('anchor-target');
+  if (!element.hasAttribute('tabindex')) {
+    element.setAttribute('tabindex', '-1');
+  }
+};
+
+// Number every vocab and exam box on the page, in document order, restarting
+// at 1 for each type. Curriculum pages are hand-written HTML with no build
+// step, so these IDs are applied in the browser rather than saved into the
+// files -- on generated summary pages just the same, since their boxes are
+// copies of the curriculum's.
+llab.addContentAnchors = () => {
+  CONTENT_ANCHORS.forEach(({ type, selector }) => {
+    document.querySelectorAll(selector).forEach((box, index) => {
+      llab.markAnchorTarget(box, llab.anchorID(type, index + 1));
+    });
+  });
+};
+
+// Scroll to the box named by the URL's #fragment. Returns whether one was
+// found. The browser cannot do this itself: it resolves the fragment while
+// the document is parsed, long before llab.addContentAnchors has assigned
+// the IDs and before quiz.js has built the self-check questions.
+llab.scrollToAnchor = () => {
+  let fragment = location.hash.slice(1);
+  if (!fragment) { return false; }
+
+  // Non-ASCII IDs (the Spanish vocab index) arrive percent-encoded.
+  let target = document.getElementById(fragment) ||
+    document.getElementById(decodeURIComponent(fragment));
+  if (!target) { return false; }
+
+  // scrollIntoView honors the scroll-margin-top that keeps the box clear of
+  // the fixed navbar; :target does not apply, as the ID postdates navigation.
+  target.scrollIntoView();
+  // Leave keyboard focus on the box the reader was sent to, so the next Tab
+  // continues from there instead of from the top of the page. This is a no-op
+  // for anything that isn't focusable.
+  target.focus({ preventScroll: true });
+  return true;
+};
+
+// Everything a fragment could name exists by "load": quiz.js builds the
+// questions on DOM ready, and llab.addContentAnchors runs before that.
+// Later fragment changes need no listener here -- by then the IDs are in the
+// document, so the browser scrolls to them itself, clear of the navbar
+// thanks to .anchor-target's scroll-margin.
+window.addEventListener('load', () => llab.scrollToAnchor());
+
 /////////////////////
 
 // Executed on *every* page load.
@@ -119,6 +192,9 @@ llab.secondarySetUp = function () {
   });
 
   llab.setupSnapImages();
+  // Ahead of the early return below: pages reached without a ?topic= (a unit
+  // vocab page opened straight from the index) still need their anchors.
+  llab.addContentAnchors();
 
   // TODO: Figure a nicer place to put all of these...
   // TODO: Rewrite the function to not scan every element.
@@ -651,7 +727,11 @@ llab.rerenderPage = (body, title, path, docLang) => {
   if (typeof buildQuestions === 'function') { buildQuestions(); } // MCQs
   llab.conditionalSetup(llab.CONDITIONAL_LOADS);
   // TODO: Do we need to fire off any events? Bootstrap? dom loaded?
-  window.scrollTo({ top: 0, behavior: 'instant' });
+  // A new page starts at the top, unless the link named a box on it. There is
+  // no "load" event for a dynamic navigation, so scroll from here instead.
+  if (!llab.scrollToAnchor()) {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }
 
   if (llab.GACode) {
     gtag('config', llab.GACode, {

--- a/llab/script/quiz/multiplechoice.js
+++ b/llab/script/quiz/multiplechoice.js
@@ -33,6 +33,13 @@ function MC(data, location, questionNumber) {
     var template = this.getTemplate();
     this.multipleChoice = $(template).insertAfter(location);
 
+    // The anchor that summary pages link back to. questionNumber is this
+    // question's place among the page's .assessment-data divs, which is what
+    // utilities/build-tools/selfcheck.rb counts; the div itself is gone by the
+    // time the page is rendered, so the ID goes on the question built from it.
+    llab.markAnchorTarget(
+        this.multipleChoice[0], llab.anchorID('self-check', this.num + 1));
+
     //boolean to prevent shuffling after each answer submit
     this.previouslyRendered = false;
 }
@@ -100,6 +107,16 @@ MC.prototype.displayNumberAttempts = function(attempts) {
     ));
 };
 
+/**
+ * Move focus to one of this question's buttons, without moving the page.
+ * Plain focus() scrolls the button into view, which on a short window jumps
+ * the question the reader is in the middle of answering.
+ */
+MC.prototype.focusButton = function(selector) {
+    let button = this.multipleChoice.find(selector)[0];
+    if (button) { button.focus({ preventScroll: true }); }
+};
+
 MC.prototype.tryAgain = function(e) {
     if (this.multipleChoice.find(".tryAgainButton").hasClass("disabled")) {
         return;
@@ -107,7 +124,7 @@ MC.prototype.tryAgain = function(e) {
     this.render();
     // render() disables the Try Again button, which would strand keyboard
     // focus; Check Answer is re-enabled by render().
-    this.multipleChoice.find('.checkAnswerButton').trigger('focus');
+    this.focusButton('.checkAnswerButton');
 };
 
 
@@ -375,7 +392,7 @@ MC.prototype.checkAnswer = function() {
     // Move focus off the now-disabled Check Answer button (disabling the
     // focused element drops focus to <body>, stranding keyboard users).
     // Try Again is always enabled at this point.
-    this.multipleChoice.find('.tryAgainButton').trigger('focus');
+    this.focusButton('.tryAgainButton');
 
     // push the state object into this mc object's own copy of states
     this.states.push(mcState);

--- a/sparks/student-pages/U1/unit-1-vocab.html
+++ b/sparks/student-pages/U1/unit-1-vocab.html
@@ -13,11 +13,11 @@
 <h2>Unit 1: Functions and Data</h2>
 <h3>Lab 1: Introduction to Snap!</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L1/01-say-hello-to-snap.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box0"><b>Lab 1, Page 1</b></a>: <strong>Block</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L1/01-say-hello-to-snap.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Block</strong>
 				<p>A <strong>block</strong> is a piece of code. If you click a block, the computer will run the code.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L1/01-say-hello-to-snap.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box1"><b>Lab 1, Page 1</b></a>: <strong>Reporters</strong> and <strong>Inputs</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L1/01-say-hello-to-snap.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 1, Page 1</b></a>: <strong>Reporters</strong> and <strong>Inputs</strong>
 			<ul>
     			<li>
 					There are several kinds of blocks in Snap<em>!</em>. The <code>say hello</code> block is a <strong>reporter</strong> block. (You can tell because it is rounded on the ends.) Reporters do a computation and then "report" the result, such as the reporter block below that is reporting the text "olá Ana."<br>
@@ -28,7 +28,7 @@
 		</div>
 <h3>Lab 2: Super Short Stories</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L2/06-adding-an-input.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box2"><b>Lab 2, Page 6</b></a>: <strong>Hat blocks</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L2/06-adding-an-input.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 6</b></a>: <strong>Hat blocks</strong>
 						<p>
 							<strong>Hat blocks</strong> tell you when a piece of code should be run and what (if any) inputs it takes.<br>
 							<img class="indent" src="/bjc-r/sparks/img/U1/lab02/plural-hat.png" alt="'plural of (word)' inside a hat-shaped block" title="'plural of (word)' inside a hat-shaped block"><br>
@@ -36,7 +36,7 @@
 						</p>
 					</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L2/06-adding-an-input.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box3"><b>Lab 2, Page 6</b></a>: <strong>Abstraction</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L2/06-adding-an-input.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 2, Page 6</b></a>: <strong>Abstraction</strong>
 			<div class="todo">
 <p>Will they be watching a video on abstraction here? Or does Dan mention it in welcome? It feels so..abstract..here that I wonder what students will take from it. If I wasn't bound to use the term abstraction, I'd probably emphasize the benefit of reuse "When we realize we've developed a useful piece of functionality that we might want to use in other places, we can turn it into its own block." Anyway just musings from your local "abstraction" skeptic, feel free to delete. -- PF 8/20/21</p>
 <p>I added your text at the beginning and am open to a Dan video and/or more discussion about teaching abstraction. :) --MF, 8/20/21</p>
@@ -47,23 +47,23 @@
 			<!--<div class="endnote">For example, you might later improve <code>plural</code> to handle words such as "fly" and "box" that don't form their plural just by adding an "s.")</div>-->
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L2/07-creating-editing-blocks.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box4"><b>Lab 2, Page 7</b></a>: <strong>Variables</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L2/07-creating-editing-blocks.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 7</b></a>: <strong>Variables</strong>
 			<div class="todo">Revisit how to do this better for the middle school level. --MF, 7/23/23</div>
 			<p>Block inputs (such as <var>job</var>, <var>action</var>, <var>number</var>, and <var>plural animal</var>) are a type of <strong>variable</strong> because the value that they provide to the <code>join</code> block <em>varies</em> based on what is typed into the input slots of the <code>super short story</code> block<!-- but they only can be used in this <em>local</em> context (you can't drag them out of the block editor and expect them to work in other parts of your code)-->.</p>
 			<div class="todo">Should this mention that block/script local is different from sprite local? -bh 2/6/22</div>
 		</div>
 <h3>Lab 4: Image Manipulation</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/01-picture-of-a-pixel.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box5"><b>Lab 4, Page 1</b></a>: <strong>Pixel</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/01-picture-of-a-pixel.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Pixel</strong>
 				<!-- Do not use <strong> for pix/el so they do not end up in the dictionary. -MB -->
 				<p>A <strong>pixel</strong> (short for <span style="font-weight: bold">pic</span>ture <span style="font-weight: bold">el</span>ement) is the smallest programmable unit of color on a screen.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/01-picture-of-a-pixel.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box6"><b>Lab 4, Page 1</b></a>: <strong>Resolution</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/01-picture-of-a-pixel.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 4, Page 1</b></a>: <strong>Resolution</strong>
 				<p><strong>Resolution</strong> is the level of detail in an image.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/02-exploring-rgb-colors.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box7"><b>Lab 4, Page 2</b></a>: <strong>List</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/02-exploring-rgb-colors.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 2</b></a>: <strong>List</strong>
 						<p>A <strong>list</strong> is an ordered sequence of items.</p>
 						<div class="endnote">
                             <a href="#hint-list" data-bs-toggle="collapse" title="Where have you seen a list before?">Where have you seen a list before?</a>
@@ -78,7 +78,7 @@
 						</div>
 					</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/03-investigating-and-storing-images.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box8"><b>Lab 4, Page 3</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/03-investigating-and-storing-images.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 3</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
 			<p>
 				A <strong>sprite</strong> is an object that has scripts and a costume and can even move around on the stage.
 				</p>
@@ -96,7 +96,7 @@
 			
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/03-investigating-and-storing-images.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box9"><b>Lab 4, Page 3</b></a>: <strong>Table</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/03-investigating-and-storing-images.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 4, Page 3</b></a>: <strong>Table</strong>
 			<p>A list is an ordered sequence of items, and a <strong>table</strong> is an ordered sequence of lists. So, <em>a table is a list of lists</em>. Each row in a table is another smaller list.
 				</p>
 <div class="endnote">
@@ -110,11 +110,11 @@
 			
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/04-pixel-mapper.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box10"><b>Lab 4, Page 4</b></a>: <strong>Abstraction</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/04-pixel-mapper.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 4</b></a>: <strong>Abstraction</strong>
 			<p>Hiding the details of <em>how</em> <code>color from pixel</code> selects the correct RGB value from a pixel (so you don't have to see the extra <code>item of</code> block) is a form of <strong>abstraction</strong>.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L4/04-pixel-mapper.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box11"><b>Lab 4, Page 4</b></a>: <strong>Higher-Order Function</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L4/04-pixel-mapper.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 4, Page 4</b></a>: <strong>Higher-Order Function</strong>
 			<p><code>Map</code> is a <strong>higher-order function</strong>. That just means that it's a function that takes a function (in this case, <code>color from pixel</code>) as input.</p>
 			<div class="endnote">
 				<p>
@@ -140,7 +140,7 @@
 		</div>
 <h3>Lab 5: Storing and Securing Data</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/01-numbers-computers.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box12"><b>Lab 5, Page 1</b></a>: <strong>Decimal Numerals</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/01-numbers-computers.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 1</b></a>: <strong>Decimal Numerals</strong>
 			<p>A <strong>decimal numeral</strong> is part of the base 10 system, the system we learn by counting on ten fingers.</p>
 			<p>In base 10, there are ten digits (0-9), and each place is worth ten times as much as the place to its right.</p>
 			<div class="endnote">
@@ -161,7 +161,7 @@
 			</div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/01-numbers-computers.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box13"><b>Lab 5, Page 1</b></a>: <strong>Binary Numerals</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/01-numbers-computers.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 5, Page 1</b></a>: <strong>Binary Numerals</strong>
 			<p>A <strong>binary numeral</strong> is part of the base 2 system.</p>
 			<p>In base 2, there are two digits (0-1), and each place is worth twice times as much as the place to its right.</p>
 			<div class="endnote">
@@ -184,11 +184,11 @@
 			</div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/02-bits-electricity.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box14"><b>Lab 5, Page 2</b></a>: <strong>Bit</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/02-bits-electricity.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 2</b></a>: <strong>Bit</strong>
             <p>The word "bit" is an abbreviation for <em><strong>bi</strong>nary digi<strong>t</strong>.</em></p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/02-bits-electricity.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box15"><b>Lab 5, Page 2</b></a>: <strong>Capacitors</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/02-bits-electricity.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 5, Page 2</b></a>: <strong>Capacitors</strong>
 			<p><strong>Capacitors</strong> store energy in an electric field (such as between two metal plates).  Here are some capacitors of varying sizes:<br>
 			</p>
 <div class="commentBig">Wikipedia claims image is in public domain: https://commons.wikimedia.org/wiki/File:Electronic-Component-Elec-Capacitors.jpg</div>
@@ -196,7 +196,7 @@
 			
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/03-hex-rgb-colors.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box16"><b>Lab 5, Page 3</b></a>: <strong>Hexadecimal Numerals</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/03-hex-rgb-colors.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 3</b></a>: <strong>Hexadecimal Numerals</strong>
 			<div class="sidenoteBig">
 				The letters A-F are used for the values 10-15:
 				<table class="byte indent" summary="values of hex digits A-F">
@@ -239,7 +239,7 @@
 			</div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L5/04-secret-messages.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box17"><b>Lab 5, Page 4</b></a>: <strong>Encryption</strong> and <strong>Decryption</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L5/04-secret-messages.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 4</b></a>: <strong>Encryption</strong> and <strong>Decryption</strong>
 			<ul>
 				<li>
 <strong>Encryption</strong> is the process of encoding data to prevent unauthorized access.</li>
@@ -249,7 +249,7 @@
 		</div>
 <h3>Lab 6: Texting Tricks</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L6/02-l33t-text.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box18"><b>Lab 6, Page 2</b></a>: <strong>Predicate</strong> and <strong>Conditional</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L6/02-l33t-text.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 6, Page 2</b></a>: <strong>Predicate</strong> and <strong>Conditional</strong>
 			<p>
                 A <strong>predicate</strong> is a hexagon-shaped reporter that asks a true/false question such as these examples:<br>
                 <img class="indent" src="/bjc-r/img/2-complexity/8-gt-7-reporting-true.png" alt="8 &gt; 7 reporting true" title="8 &gt; 7 reporting true">
@@ -260,17 +260,17 @@
 			</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L6/03-emojify.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box19"><b>Lab 6, Page 3</b></a>: <strong>Higher-Order Function</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L6/03-emojify.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 6, Page 3</b></a>: <strong>Higher-Order Function</strong>
 			<p>Like <code>map</code>, the <code>find first</code> block is a <strong>higher-order function</strong> because it takes a function (the predicate) as input.</p>
 		</div>
 <h3>Lab 7: Dealing with Data Dos</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L7/02-setting-up.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box20"><b>Lab 7, Page 2</b></a>: <strong>Variable</strong> and <strong>Table</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L7/02-setting-up.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-1"><b>Lab 7, Page 2</b></a>: <strong>Variable</strong> and <strong>Table</strong>
 			<p>A <strong>variable</strong> is like a box that can store a value, such as a word, a number, or a list.</p>
 			<p>In Snap<em>!</em>, a <strong>table</strong> is a list of lists (a list with lists inside it).</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U1/L7/02-setting-up.html?topic=sparks/1-functions-data.topic&course=sparks.html" id="box21"><b>Lab 7, Page 2</b></a>: <strong>Watcher</strong>
+<a href="/bjc-r/sparks/student-pages/U1/L7/02-setting-up.html?topic=sparks/1-functions-data.topic&course=sparks.html#vocab-2"><b>Lab 7, Page 2</b></a>: <strong>Watcher</strong>
 				<p>A <strong>watcher</strong> is a window that lets you see what value is stored in a variable.</p>
 			</div>
 

--- a/sparks/student-pages/U2/unit-2-vocab.html
+++ b/sparks/student-pages/U2/unit-2-vocab.html
@@ -13,15 +13,15 @@
 <h2>Unit 2: Sequencing and Iteration</h2>
 <h3>Lab 1: Song Player</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/01-playing-notes.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box22"><b>Lab 1, Page 1</b></a>: <strong>Command</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/01-playing-notes.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Command</strong>
 						<p>A <strong>command</strong> block tells the computer to do something <em>without reporting a value</em>.</p>
 					</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/02-visualizing-loops.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box23"><b>Lab 1, Page 2</b></a>: <strong>Looping</strong> or <strong>Iteration</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/02-visualizing-loops.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 2</b></a>: <strong>Looping</strong> or <strong>Iteration</strong>
 				<p>Repeating the same set of commands (such as with <code>repeat</code> or <code>forever</code>) is called <strong>looping</strong> or <strong>iteration</strong>.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/03-programming-styles.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box24"><b>Lab 1, Page 3</b></a>: <strong>Reporters</strong>, <strong>Predicates</strong>, and <strong>Commands</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/03-programming-styles.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 3</b></a>: <strong>Reporters</strong>, <strong>Predicates</strong>, and <strong>Commands</strong>
 			<div class="sidenote">You learned about reporters in <a href="/bjc-r/sparks/student-pages/U1/L1/04-say-hello-to-snap.html?topic=sparks%2F1-functions-data.topic&course=middle-school.html" title="Unit 1 Lab 1 Activity 4: Say Hello to Snap!">Unit 1 Lab 1 Activity 4: Say Hello to Snap<em>!</em></a>.</div>
 			<p>
 				A <strong>reporter</strong> block does a calculation and reports the result. Reporters have an oval shape. <br>
@@ -46,11 +46,11 @@
 			<div class="endnote" style="clear: right;">Unlike reporters, a command block doesn't report anything, so you can't use its result as the input to another block—its result is an action, not a value!</div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/03-programming-styles.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box25"><b>Lab 1, Page 3</b></a>: <strong>Abstraction</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/03-programming-styles.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-2"><b>Lab 1, Page 3</b></a>: <strong>Abstraction</strong>
 				<p>Hiding away the details of how code works (such as by moving it inside a new block) is a form of <em>abstraction</em>.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/05-beat-repeat.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box26"><b>Lab 1, Page 5</b></a>: <strong>List</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/05-beat-repeat.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 5</b></a>: <strong>List</strong>
 			<p>A <strong>list</strong> is an ordered sequence of items. You've been using lists throughout this course: to store words for a story, to manipulate the letters of a secret message, and even to store lists such as each individual's responses to the question in a survey.</p>
 			<div class="endnote">
 				<a href="#ordered" data-bs-toggle="collapse" title="What does 'ordered' mean?">What does "ordered" mean?</a>
@@ -64,23 +64,23 @@
 			</div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/06-storing-songs.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box27"><b>Lab 1, Page 6</b></a>: <strong>Global Variable</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/06-storing-songs.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 6</b></a>: <strong>Global Variable</strong>
             <p>A <strong>global variable</strong> is a variable that is usable by all scripts in the program.</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L1/07-song-mapper.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box28"><b>Lab 1, Page 7</b></a>: <strong>Higher-Order Function</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L1/07-song-mapper.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 7</b></a>: <strong>Higher-Order Function</strong>
 			<p>Recall, a function that takes a function as input (like <code>map</code>) is called a <strong>higher-order function</strong>.</p>
 		</div>
 <h3>Lab 2: Graphics and Animation</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L2/01-costumes-backgrounds.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box29"><b>Lab 2, Page 1</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L2/01-costumes-backgrounds.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Sprites</strong> and <strong>Costumes</strong>
 			<ul>
 				<li>A <strong>sprite</strong> is like an actor who can do many different things, such as move, talk, follow other sprites, and whatever else you program it to do!</li>
 				<li>A <strong>costume</strong> is a picture that can be "worn" by a sprite.</li>
 			</ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L2/01-costumes-backgrounds.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box30"><b>Lab 2, Page 1</b></a>: <strong>Stage</strong> and <strong>Background</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L2/01-costumes-backgrounds.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-2"><b>Lab 2, Page 1</b></a>: <strong>Stage</strong> and <strong>Background</strong>
 			<ul>
 				<li>The <strong>stage</strong> is the big rectangle in the upper right of the Snap<em>!</em> window. (It's white when you first open Snap<em>!</em>.) The stage is what users of your project see, and it's where your sprites live.</li>
 				<li>A <strong>background</strong> is a picture that can be "worn" by the stage.
@@ -89,11 +89,11 @@
 			</ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L2/09-responding-events.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box31"><b>Lab 2, Page 9</b></a>: <strong>Event</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L2/09-responding-events.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 9</b></a>: <strong>Event</strong>
 			<p>An <strong>event</strong> is something that happens, such as clicking on a sprite, pressing a key, or clicking the green flag button (<img class="inline" src="/bjc-r/img/sys/button-green-flag.png" alt="green-flag button" title="green-flag button">) that tells the computer to do something.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L2/13-setting-up-click-areas.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box32"><b>Lab 2, Page 13</b></a>: <strong>Predicate</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L2/13-setting-up-click-areas.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 13</b></a>: <strong>Predicate</strong>
 			<p>
 				A <strong>predicate</strong> is a hexagon-shaped reporter that asks a true/false question.
 			</p>
@@ -101,7 +101,7 @@
 		</div>
 <h3>Lab 3: Make Some Noise</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L3/01-visualizing-sound-data.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box33"><b>Lab 3, Page 1</b></a>: <strong>Oscilloscope</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L3/01-visualizing-sound-data.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Oscilloscope</strong>
 			<ul>
 				<li>An <strong>oscilloscope</strong> is an instrument that graphs a signal's intensity over time. You'll create a sound oscilloscope that shows volume (loudness) over time.
 					<div class="sidenote"><small>Image from Wikipedia user Pittigrilli.</small></div>
@@ -110,14 +110,14 @@
 			</ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L3/03-spectrum-analyzer.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box34"><b>Lab 3, Page 3</b></a>: <strong>Frequency</strong> and <strong>Spectrum Analyzer</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L3/03-spectrum-analyzer.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 3, Page 3</b></a>: <strong>Frequency</strong> and <strong>Spectrum Analyzer</strong>
 			<ul>
 				<li>The <strong>frequency</strong> of a sound is its pitch. High frequencies sound "high" (sharp), and low frequencies sound "low" (boomy).</li>
 				<li>An <strong>spectrum analyzer</strong> is an instrument that graphs a signal's intensity at each frequency. You'll create a sound spectrum analyzer that shows the volume of each frequency.</li>
 			</ul>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L3/05-making-noise.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box35"><b>Lab 3, Page 5</b></a>: <strong>Sample Rate</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L3/05-making-noise.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 3, Page 5</b></a>: <strong>Sample Rate</strong>
 						<p>
 							The <strong>sample rate</strong> is how many intensity samples fit in one second of sound samples detected by the microphone.<br>
 							<img class="indent" src="/bjc-r/sparks/img/U2/lab05/sample-rate-mic-samples-reporting.png" alt="(sample rate) of sound (microphone(samples)) reporting 44100" title="(sample rate) of sound (microphone(samples)) reporting 44100">
@@ -125,21 +125,21 @@
 					</div>
 <h3>Lab 4: Routing Protocols</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L4/01-routing.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box36"><b>Lab 4, Page 1</b></a>: <strong>Router</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L4/01-routing.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Router</strong>
 			<p>A <strong>router</strong> is a special type of computing device that knows how to send messages to other internet-connected devices.</p>
 			<img class="" src="/bjc-r/sparks/img/U2/lab04/router.jpg" alt="image of a router with one line input, 4 ethernet outputs, and a power socket" title="image of a router with one line input, 4 ethernet outputs, and a power socket">
 			<div class="endnote"><small>Image by Wikipedia user Asim18.</small></div>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L4/01-routing.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box37"><b>Lab 4, Page 1</b></a>: <strong>Protocol</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L4/01-routing.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-2"><b>Lab 4, Page 1</b></a>: <strong>Protocol</strong>
 			<p>A <strong>protocol</strong> is a standard set of rules for communication that everyone agrees to.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L4/02-redundancy.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box38"><b>Lab 4, Page 2</b></a>: <strong>Redundancy</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L4/02-redundancy.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 2</b></a>: <strong>Redundancy</strong>
 				<p>Network <strong>redundancy</strong> means multiple paths to get to the same place.</p>
 			</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U2/L4/02-redundancy.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html" id="box39"><b>Lab 4, Page 2</b></a>: <strong>SPOF</strong>
+<a href="/bjc-r/sparks/student-pages/U2/L4/02-redundancy.html?topic=sparks/2-sequencing-iteration.topic&course=sparks.html#vocab-2"><b>Lab 4, Page 2</b></a>: <strong>SPOF</strong>
 			<p>In a network, a <strong>single point of failure (SPOF)</strong> is any connection that will bring down a piece of the network if it fails.</p>
 		</div>
 

--- a/sparks/student-pages/U3/unit-3-vocab.html
+++ b/sparks/student-pages/U3/unit-3-vocab.html
@@ -13,44 +13,44 @@
 <h2>Unit 3: Hardware</h2>
 <h3>Lab 1: Meet micro:bit</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L1/01-get-ready.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box40"><b>Lab 1, Page 1</b></a>: <strong>Software Library</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L1/01-get-ready.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 1, Page 1</b></a>: <strong>Software Library</strong>
 			<p>A <strong>software library</strong> is a collection of procedures (blocks) that can be used in programs.</p>
 		</div>
 <h3>Lab 2: Interactive Pet</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L2/01-designing-pet.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box41"><b>Lab 2, Page 1</b></a>: <strong>Input and Output</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L2/01-designing-pet.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 2, Page 1</b></a>: <strong>Input and Output</strong>
 			<p>In computing, the <strong>input</strong> is the action that tells the computer to do something. The <strong>output</strong> is the resulting action that occurs after the input command is received.</p>
             <p>The micro:bit has different types of inputs: light (bright or dark), button pressed, or certain movement. The output we're currently exploring is displaying a picture on the LED display.</p>
         </div>
 <h3>Lab 3: Game Play</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L3/01-game-design.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box42"><b>Lab 3, Page 1</b></a>: <strong>Variable</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L3/01-game-design.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 3, Page 1</b></a>: <strong>Variable</strong>
 			<p>A <strong>variable</strong> is like a labeled box that can store a value, such as a word, a number, or a list.</p>
 		</div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L3/01-game-design.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box43"><b>Lab 3, Page 1</b></a>: <strong>Analog Input Pin</strong> and <strong>Switch</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L3/01-game-design.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-2"><b>Lab 3, Page 1</b></a>: <strong>Analog Input Pin</strong> and <strong>Switch</strong>
 			<p>An <strong>analog input pin</strong> can read a voltage level that ranges of voltages provided to your micro:bit. </p>
 
 			<p>A <strong>switch</strong> is an electronic device that disconnects or connects and electrical path, resulting in a circuit turning off or on. </p>
 		</div>
 <h3>Lab 4: Marvelous Motions</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L4/01-make-it-move.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box44"><b>Lab 4, Page 1</b></a>: <strong>Servo Motor</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L4/01-make-it-move.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 4, Page 1</b></a>: <strong>Servo Motor</strong>
 			<p>A <strong>servo motor</strong> (or just <strong>servo</strong>) provides position control, so it can be told to move into an exact spot. Its position can be selected from 0 to 180 degrees.</p>
 		</div>
 <h3>Lab 5: Paper Stories</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L5/01-led-it-glow.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box45"><b>Lab 5, Page 1</b></a>: <strong>LED</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L5/01-led-it-glow.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 1</b></a>: <strong>LED</strong>
 			<p>An <strong>LED</strong> contains a light emitter inside of a plastic bulb. This light emitter can be made from different materials, and when electricity runs through it, it shines different colors. However, electricity can only flow in one direction, and the name for electronic parts with this quality is called a diode. LED stands for "light-emitting diode."</p>
         </div>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L5/03-paper-story.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box46"><b>Lab 5, Page 3</b></a>: <strong>Parallel Circuit</strong> and <strong>Series Circuit</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L5/03-paper-story.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 5, Page 3</b></a>: <strong>Parallel Circuit</strong> and <strong>Series Circuit</strong>
                     <p>A <strong>parallel circuit</strong> has multiple branches and allows for easier addition of multiple LEDs. In parallel, the LEDs retain most of their brightness.</p>
                     <p>A <strong>series circuit</strong> has all elements in a chain, one after another and makes a complete circle. In series, the more LEDs added, the dimmer they become. </p>
                 </div>
 <h3>Lab 6: Making with Multiples</h3>
 <div class="vocab summaryBox">
-<a href="/bjc-r/sparks/student-pages/U3/L6/01-send-a-signal.html?topic=sparks/3-hardware.topic&course=sparks.html" id="box47"><b>Lab 6, Page 1</b></a>: <strong>Radio Communication</strong>
+<a href="/bjc-r/sparks/student-pages/U3/L6/01-send-a-signal.html?topic=sparks/3-hardware.topic&course=sparks.html#vocab-1"><b>Lab 6, Page 1</b></a>: <strong>Radio Communication</strong>
 			<p><strong>Radio</strong> is a way of transmitting and receiving information over a distance.</p>
         </div>
 

--- a/sparks/student-pages/vocab-index.html
+++ b/sparks/student-pages/vocab-index.html
@@ -43,219 +43,219 @@
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="A">A</h2>
             <ol style="list-style-type: square">
-              <li>abstraction   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box3">1.2.6</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box10">1.4.4</a>
+              <li>abstraction   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-4">1.2.6</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-11">1.4.4</a>
               </li>
-              <li>analog input pin   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box43">3.3.1</a>
+              <li>analog input pin   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-4">3.3.1</a>
               </li>
-              <li>analyzer, spectrum   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box34">2.3.3</a>
+              <li>analyzer, spectrum   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-13">2.3.3</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="B">B</h2>
             <ol style="list-style-type: square">
-              <li>background   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box30">2.2.1</a>
+              <li>background   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-9">2.2.1</a>
               </li>
-              <li>binary numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box13">1.5.1</a>
+              <li>binary numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-14">1.5.1</a>
               </li>
-              <li>block   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box0">1.1.1</a>
+              <li>block   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-1">1.1.1</a>
               </li>
-              <li>blocks, hat   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box2">1.2.6</a>
+              <li>blocks, hat   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-3">1.2.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="C">C</h2>
             <ol style="list-style-type: square">
-              <li>capacitors   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box15">1.5.2</a>
+              <li>capacitors   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-16">1.5.2</a>
               </li>
-              <li>circuit, parallel   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box46">3.5.3</a>
+              <li>circuit, parallel   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-7">3.5.3</a>
               </li>
-              <li>circuit, series   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box46">3.5.3</a>
+              <li>circuit, series   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-7">3.5.3</a>
               </li>
-              <li>command   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box22">2.1.1</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box24">2.1.3</a>
+              <li>command   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-1">2.1.1</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-3">2.1.3</a>
               </li>
-              <li>conditional   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box18">1.6.2</a>
+              <li>conditional   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-19">1.6.2</a>
               </li>
-              <li>costume   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box8">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box29">2.2.1</a>
+              <li>costume   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-9">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-8">2.2.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="D">D</h2>
             <ol style="list-style-type: square">
-              <li>decimal numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box12">1.5.1</a>
+              <li>decimal numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-13">1.5.1</a>
               </li>
-              <li>decryption   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box17">1.5.4</a>
+              <li>decryption   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-18">1.5.4</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="E">E</h2>
             <ol style="list-style-type: square">
-              <li>encryption   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box17">1.5.4</a>
+              <li>encryption   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-18">1.5.4</a>
               </li>
-              <li>event   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box31">2.2.9</a>
+              <li>event   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-10">2.2.9</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="F">F</h2>
             <ol style="list-style-type: square">
-              <li>failure, single point of   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box39">2.4.2</a>
+              <li>failure, single point of   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-18">2.4.2</a>
               </li>
-              <li>frequency   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box34">2.3.3</a>
+              <li>frequency   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-13">2.3.3</a>
               </li>
-              <li>function, higher-order   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box11">1.4.4</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box19">1.6.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box28">2.1.7</a>
+              <li>function, higher-order   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-12">1.4.4</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-20">1.6.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-7">2.1.7</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="G">G</h2>
             <ol style="list-style-type: square">
-              <li>global variable   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box27">2.1.6</a>
+              <li>global variable   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-6">2.1.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="H">H</h2>
             <ol style="list-style-type: square">
-              <li>hat blocks   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box2">1.2.6</a>
+              <li>hat blocks   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-3">1.2.6</a>
               </li>
-              <li>hexadecimal numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box16">1.5.3</a>
+              <li>hexadecimal numeral   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-17">1.5.3</a>
               </li>
-              <li>higher-order function   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box11">1.4.4</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box19">1.6.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box28">2.1.7</a>
+              <li>higher-order function   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-12">1.4.4</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-20">1.6.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-7">2.1.7</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="I">I</h2>
             <ol style="list-style-type: square">
-              <li>input   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box1">1.1.1</a>, <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box41">3.2.1</a>
+              <li>input   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-2">1.1.1</a>, <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-2">3.2.1</a>
               </li>
-              <li>iteration   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box23">2.1.2</a>
+              <li>iteration   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-2">2.1.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="L">L</h2>
             <ol style="list-style-type: square">
-              <li>led   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box45">3.5.1</a>
+              <li>led   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-6">3.5.1</a>
               </li>
-              <li>library, software   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box40">3.1.1</a>
+              <li>library, software   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-1">3.1.1</a>
               </li>
-              <li>list   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box7">1.4.2</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box26">2.1.5</a>
+              <li>list   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-8">1.4.2</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-5">2.1.5</a>
               </li>
-              <li>looping   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box23">2.1.2</a>
+              <li>looping   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-2">2.1.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="M">M</h2>
             <ol style="list-style-type: square">
-              <li>motor, servo   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box44">3.4.1</a>
+              <li>motor, servo   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-5">3.4.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="N">N</h2>
             <ol style="list-style-type: square">
-              <li>numeral, binary   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box13">1.5.1</a>
+              <li>numeral, binary   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-14">1.5.1</a>
               </li>
-              <li>numeral, decimal   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box12">1.5.1</a>
+              <li>numeral, decimal   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-13">1.5.1</a>
               </li>
-              <li>numeral, hexadecimal   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box16">1.5.3</a>
+              <li>numeral, hexadecimal   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-17">1.5.3</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="O">O</h2>
             <ol style="list-style-type: square">
-              <li>oscilloscope   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box33">2.3.1</a>
+              <li>oscilloscope   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-12">2.3.1</a>
               </li>
-              <li>output   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box41">3.2.1</a>
+              <li>output   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-2">3.2.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="P">P</h2>
             <ol style="list-style-type: square">
-              <li>parallel circuit   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box46">3.5.3</a>
+              <li>parallel circuit   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-7">3.5.3</a>
               </li>
-              <li>pin, analog input   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box43">3.3.1</a>
+              <li>pin, analog input   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-4">3.3.1</a>
               </li>
-              <li>pixel   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box5">1.4.1</a>
+              <li>pixel   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-6">1.4.1</a>
               </li>
-              <li>predicate   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box18">1.6.2</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box24">2.1.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box32">2.2.13</a>
+              <li>predicate   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-19">1.6.2</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-3">2.1.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-11">2.2.13</a>
               </li>
-              <li>protocol   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box37">2.4.1</a>
+              <li>protocol   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-16">2.4.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="R">R</h2>
             <ol style="list-style-type: square">
-              <li>radio   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box47">3.6.1</a>
+              <li>radio   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-8">3.6.1</a>
               </li>
-              <li>rate, sample   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box35">2.3.5</a>
+              <li>rate, sample   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-14">2.3.5</a>
               </li>
-              <li>redundancy   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box38">2.4.2</a>
+              <li>redundancy   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-17">2.4.2</a>
               </li>
-              <li>reporter   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box1">1.1.1</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box24">2.1.3</a>
+              <li>reporter   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-2">1.1.1</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-3">2.1.3</a>
               </li>
-              <li>resolution   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box6">1.4.1</a>
+              <li>resolution   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-7">1.4.1</a>
               </li>
-              <li>router   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box36">2.4.1</a>
+              <li>router   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-15">2.4.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="S">S</h2>
             <ol style="list-style-type: square">
-              <li>sample rate   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box35">2.3.5</a>
+              <li>sample rate   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-14">2.3.5</a>
               </li>
-              <li>series circuit   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box46">3.5.3</a>
+              <li>series circuit   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-7">3.5.3</a>
               </li>
-              <li>servo   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box44">3.4.1</a>
+              <li>servo   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-5">3.4.1</a>
               </li>
-              <li>servo motor   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box44">3.4.1</a>
+              <li>servo motor   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-5">3.4.1</a>
               </li>
-              <li>single point of failure (SPOF)   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box39">2.4.2</a>
+              <li>single point of failure (SPOF)   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-18">2.4.2</a>
               </li>
-              <li>software library   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box40">3.1.1</a>
+              <li>software library   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-1">3.1.1</a>
               </li>
-              <li>spectrum analyzer   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box34">2.3.3</a>
+              <li>spectrum analyzer   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-13">2.3.3</a>
               </li>
-              <li>SPOF   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box39">2.4.2</a>
+              <li>SPOF   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-18">2.4.2</a>
               </li>
-              <li>sprite   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box8">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box29">2.2.1</a>
+              <li>sprite   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-9">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-8">2.2.1</a>
               </li>
-              <li>stage   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box30">2.2.1</a>
+              <li>stage   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-9">2.2.1</a>
               </li>
-              <li>switch   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box43">3.3.1</a>
+              <li>switch   <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-4">3.3.1</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="T">T</h2>
             <ol style="list-style-type: square">
-              <li>table   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box9">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box20">1.7.2</a>
+              <li>table   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-10">1.4.3</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-21">1.7.2</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="V">V</h2>
             <ol style="list-style-type: square">
-              <li>variable   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box4">1.2.7</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box20">1.7.2</a>, <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#box42">3.3.1</a>
+              <li>variable   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-5">1.2.7</a>, <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-21">1.7.2</a>, <a href="/bjc-r/sparks/student-pages/U3/unit-3-vocab.html?topic=sparks/3-hardware.topic&amp;course=sparks.html#vocab-3">3.3.1</a>
               </li>
-              <li>variable, global   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#box27">2.1.6</a>
+              <li>variable, global   <a href="/bjc-r/sparks/student-pages/U2/unit-2-vocab.html?topic=sparks/2-sequencing-iteration.topic&amp;course=sparks.html#vocab-6">2.1.6</a>
               </li>
             </ol>
           </li>
           <li class="index-letter-target" style="list-style-type: none">
             <h2 id="W">W</h2>
             <ol style="list-style-type: square">
-              <li>watcher   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#box21">1.7.2</a>
+              <li>watcher   <a href="/bjc-r/sparks/student-pages/U1/unit-1-vocab.html?topic=sparks/1-functions-data.topic&amp;course=sparks.html#vocab-22">1.7.2</a>
               </li>
             </ol>
           </li>

--- a/utilities/build-tools/bjc_helpers.rb
+++ b/utilities/build-tools/bjc_helpers.rb
@@ -89,6 +89,15 @@ module BJCHelpers
     @currUnit.scan(/\d+/).join('.')
   end
 
+  # The ID of the NUMBERth content box of TYPE on a page, counting from 1,
+  # e.g. "vocab-3". Curriculum pages have no build step, so nothing writes
+  # these IDs into the HTML: llab.addContentAnchors and multiplechoice.js
+  # assign them in the browser, numbering boxes exactly as the generators
+  # here do. llab.anchorID is the other half of this agreement.
+  def anchor_id(type, number)
+    "#{type}-#{number}"
+  end
+
   # "Lab 2: Interactive Pet" for the title above.
   def currLab
     return if @currUnit.nil?

--- a/utilities/build-tools/selfcheck.rb
+++ b/utilities/build-tools/selfcheck.rb
@@ -9,6 +9,10 @@ require_relative 'bjc_helpers'
 class SelfCheck
   include BJCHelpers
 
+  # The anchor type each kind of box uses on the curriculum page it came from.
+  # Keyed like @page_content, by the summary page the box ends up on.
+  ANCHOR_TYPES = { 'Self-Check' => 'self-check', 'Exam' => 'exam' }.freeze
+
   def initialize(path, language, content, course)
     @parentPath = path
     # The generators are handed the content folder; the checkout root is what
@@ -23,7 +27,9 @@ class SelfCheck
     @language = language
     @language_ext = language_ext(language)
     I18n.locale = @language.to_sym
-    @box_num = 0
+    # Where a box sits, counting from 1, on the curriculum page it was read
+    # from. Per page and per type, matching how the browser numbers them.
+    @source_box_num = ANCHOR_TYPES.transform_values { 0 }
     # Track the previous lab/section heading for the self-check+exam page.
     # If it changes, then we need to insert a new page heading.
     @priorPageHeading = { 'Self-Check' => nil, 'Exam' => nil }
@@ -60,14 +66,11 @@ class SelfCheck
     "unit-#{@currUnitNum}-exam-reference#{@language_ext}.html"
   end
 
-  def box_num(num)
-    @box_num = num
-  end
-
   def read_file(file)
     return unless File.exist?(file)
 
     currFile(file)
+    @source_box_num = ANCHOR_TYPES.transform_values { 0 }
     # puts "Reading file: #{file}"
     doc = File.open(file) { |f| Nokogiri::HTML(f) }
     parse_unit(doc)
@@ -107,7 +110,7 @@ class SelfCheck
       node.attributes['responseidentifier'].value = unique_id
       node.children.before(<<~HTML
         <div class="additional-info">
-          #{add_unit_to_header}
+          #{add_unit_to_header('Self-Check')}
         </div>
       HTML
                           )
@@ -122,7 +125,7 @@ class SelfCheck
 
     on_exam_boxes.each do |node|
       node['class'] = 'exam summaryBox'
-      node.children.before(add_unit_to_header)
+      node.children.before(add_unit_to_header('Exam'))
     end
 
     add_exam_to_file(on_exam_boxes.to_s)
@@ -160,10 +163,13 @@ class SelfCheck
     content << data
   end
 
-  def add_unit_to_header
+  # The "from Lab 1, Page 4" link a copied box carries, pointing back at the
+  # box itself on the curriculum page. TYPE is a key of ANCHOR_TYPES.
+  def add_unit_to_header(type)
     page_number = BJCHelpers.lab_page_number(@currUnit)
-    box_num(@box_num + 1)
-    link = "#{url_for(@currFile)}#{topic_url_suffix}#box#{@box_num}"
+    @source_box_num[type] += 1
+    anchor = anchor_id(ANCHOR_TYPES[type], @source_box_num[type])
+    link = "#{url_for(@currFile)}#{topic_url_suffix}##{anchor}"
     " #{I18n.t('from')} <a href=\"#{link}\"><strong>#{page_number}</strong></a>"
   end
 

--- a/utilities/build-tools/vocab.rb
+++ b/utilities/build-tools/vocab.rb
@@ -34,8 +34,13 @@ class Vocab
     @vocab_url_map = {}
     @currUnitName = nil
     @index = Index.new(@parentDir, @language)
-    # TODO: See if we can remove this.
-    @current_box_num = 0
+    # Where a vocab box sits, counting from 1, on each of the two pages that
+    # link to it: the curriculum page it was read from (which the box's own
+    # "Lab 1, Page 4" link points back at) and the unit vocab page being
+    # generated (which the vocab index points at). They run at different
+    # rates -- one unit page collects the boxes of many curriculum pages.
+    @source_box_num = 0
+    @page_box_num = 0
     @language_ext = language_ext(language)
     # (For now) also store the current file content as a string, so we can write the file only once.
     @current_file_content = +''
@@ -80,6 +85,7 @@ class Vocab
     return unless File.exist?(file)
 
     currFile(file)
+    @source_box_num = 0
     parse_unit(file)
     parse_vocab(file)
     puts "Vocab Completed: #{@currUnit}"
@@ -109,6 +115,7 @@ class Vocab
   # then resets the buffer so the next unit starts a fresh file.
   # Nothing is written to disk here.
   def finalize_unit(unit_dir)
+    @page_box_num = 0
     return {} if @current_file_content.empty?
 
     contents = @current_file_content + BJCHelpers.summary_page_suffix
@@ -134,11 +141,13 @@ class Vocab
     xpath_selector = VOCAB_CLASSES.map { |class_name| "//div[contains(@class, '#{class_name}')]" }.join(' | ')
     doc.xpath(xpath_selector).each do |node|
       node['class'] = 'vocab summaryBox'
+      # Both counters advance before the box is described, since the header
+      # link and the index entry below name the box just counted.
+      @source_box_num += 1
+      @page_box_num += 1
       child = node.children
       child.before(add_vocab_unit_to_header) # if !child.to_a.include?(add_vocab_unit_to_header)
       get_vocab_word(node) # This saves the extracted term for later.
-      # TODO: see if we can remove this tracking of the box number.
-      @current_box_num += 1
       add_vocab_to_file(node.to_s)
     end
   end
@@ -240,18 +249,24 @@ class Vocab
     end
   end
 
+  # The vocab index's link to a term, pointing at the box on the unit vocab
+  # page that defines it.
   def add_vocab_unit_to_index
     path = get_prev_folder(Dir.pwd, include_path: true)
-    "<a href=\"#{url_for(vocab_file_name, path)}#{topic_url_suffix}#box#{@current_box_num}\">#{unit_reference}</a>"
+    anchor = anchor_id('vocab', @page_box_num)
+    "<a href=\"#{url_for(vocab_file_name, path)}#{topic_url_suffix}##{anchor}\">#{unit_reference}</a>"
   end
 
+  # The box's own link back to the curriculum page it was copied from, and to
+  # the box's place on it.
   # NOTE: There should be no whitespace after the <a> tag so the `:` is right next to the link.
   def add_vocab_unit_to_header
     page_text = BJCHelpers.lab_page_number(@currUnit)
     # Capitalize the first letter of the page text
     # This really only makes a difference for the Spanish translation, since English is already capitalized.
     page_text = page_text.capitalize if @language == 'es'
-    "<a href=\"#{url_for(@currFile)}#{topic_url_suffix}\" id=\"box#{@current_box_num}\"><b>#{page_text}</b></a>"
+    anchor = anchor_id('vocab', @source_box_num)
+    "<a href=\"#{url_for(@currFile)}#{topic_url_suffix}##{anchor}\"><b>#{page_text}</b></a>"
   end
 
   def add_vocab_to_file(vocab)

--- a/utilities/specs/build_tools_spec.rb
+++ b/utilities/specs/build_tools_spec.rb
@@ -49,19 +49,39 @@ module BuildToolsFixture
     </div>
   HTML
 
-  SELF_CHECK_BOX = <<~HTML
-    <div class="assessment-data" responseIdentifier="ri1">
-      <div class="responseDeclaration" identifier="ri1"></div>
+  # A second box of each kind, so the per-page numbering behind the #vocab-2 /
+  # #self-check-2 anchors has something to count past.
+  SECOND_VOCAB_BOX = <<~HTML
+    <div class="vocabFullWidth">
+      <p>A <strong>Gizmo</strong> is a fancier thing.</p>
     </div>
   HTML
 
+  def self.self_check_box(identifier)
+    <<~HTML
+      <div class="assessment-data" responseIdentifier="#{identifier}">
+        <div class="responseDeclaration" identifier="#{identifier}"></div>
+      </div>
+    HTML
+  end
+
+  SELF_CHECK_BOX = self_check_box('ri1')
+  SECOND_SELF_CHECK_BOX = self_check_box('ri2')
+
   EXAM_BOX = '<div class="examFullWidth"><p>On the exam, widgets are called gizmos.</p></div>'
+  SECOND_EXAM_BOX = '<div class="examFullWidth"><p>The exam spells it "widgit".</p></div>'
   ATWORK_BOX = '<div class="atwork"><p>Ada Lovelace built widgets.</p></div>'
 
   PAGES = {
-    '1-basics/1-meet.html' => ['Unit 1 Lab 1: Widget Basics, Page 1', VOCAB_BOX + ATWORK_BOX],
-    '1-basics/2-quiz.html' => ['Unit 1 Lab 1: Widget Basics, Page 2', SELF_CHECK_BOX + EXAM_BOX],
-    '2-practice/1-review.html' => ['Unit 1 Lab 2: Widget Practice, Page 1', VOCAB_BOX]
+    '1-basics/1-meet.html' => ['Unit 1 Lab 1: Widget Basics, Page 1',
+                               VOCAB_BOX + SECOND_VOCAB_BOX + ATWORK_BOX],
+    '1-basics/2-quiz.html' => ['Unit 1 Lab 1: Widget Basics, Page 2',
+                               SELF_CHECK_BOX + SECOND_SELF_CHECK_BOX + EXAM_BOX + SECOND_EXAM_BOX],
+    # A second page carrying every kind of box, so a counter that failed to
+    # restart would be visible here. The same vocab term again, too: it is the
+    # third vocab box of the generated unit page but the first of this one.
+    '2-practice/1-review.html' => ['Unit 1 Lab 2: Widget Practice, Page 1',
+                                   VOCAB_BOX + SELF_CHECK_BOX + EXAM_BOX]
   }.freeze
 
   def self.page(title, body)
@@ -404,6 +424,60 @@ RSpec.describe 'build tools', type: :build_tools do
         titles = BJCTopic.new(topic_file).parse[:topics].first[:content].map { |section| section[:title] }
 
         expect(titles.count { |title| BJCTopic.summary_heading?(title) }).to eq(1)
+      end
+
+      # Nothing writes these IDs into the HTML -- llab.addContentAnchors and
+      # multiplechoice.js assign them in the browser. All the examples below
+      # can check is that the generators count boxes the same way.
+      def source_link(page, anchor)
+        "/bjc-r/cur/testing/1-widgets/#{page}?topic=testing/1-widgets.topic&course=test.html##{anchor}"
+      end
+
+      it 'sends a vocab box back to its own position on the page it came from' do
+        vocab = File.read(File.join(unit_directory, 'unit-1-vocab.html'))
+
+        expect(vocab).to include(source_link('1-basics/1-meet.html', 'vocab-1'),
+                                 source_link('1-basics/1-meet.html', 'vocab-2'))
+      end
+
+      it 'restarts the numbering on each page, rather than running unit-wide' do
+        vocab = File.read(File.join(unit_directory, 'unit-1-vocab.html'))
+
+        # The third box of the unit, but the first one on its own page.
+        expect(vocab).to include(source_link('2-practice/1-review.html', 'vocab-1'))
+        expect(vocab).not_to include(source_link('2-practice/1-review.html', 'vocab-3'))
+      end
+
+      it 'restarts the self-check and exam numbering on each page too' do
+        self_check = File.read(File.join(unit_directory, 'unit-1-self-check.html'))
+        exam = File.read(File.join(unit_directory, 'unit-1-exam-reference.html'))
+
+        # The unit's third self-check and third exam box, both the first on
+        # the page they came from.
+        expect(self_check).to include(source_link('2-practice/1-review.html', 'self-check-1'))
+        expect(exam).to include(source_link('2-practice/1-review.html', 'exam-1'))
+      end
+
+      it 'numbers self-checks and exam boxes separately' do
+        self_check = File.read(File.join(unit_directory, 'unit-1-self-check.html'))
+        exam = File.read(File.join(unit_directory, 'unit-1-exam-reference.html'))
+
+        expect(self_check).to include(source_link('1-basics/2-quiz.html', 'self-check-1'),
+                                      source_link('1-basics/2-quiz.html', 'self-check-2'))
+        # Both kinds share a page here, so a single counter would start the
+        # exam boxes at 3.
+        expect(exam).to include(source_link('1-basics/2-quiz.html', 'exam-1'),
+                                source_link('1-basics/2-quiz.html', 'exam-2'))
+      end
+
+      it 'sends a vocab index entry to the box position on the page it links to' do
+        index = File.read(File.join(root, 'cur', 'testing', 'vocab-index.html'))
+        unit_page = 'unit-1-vocab.html?topic=testing/1-widgets.topic&amp;course=test.html'
+
+        # "Widget" is defined twice: first and third box of the unit page.
+        expect(index).to include("#{unit_page}#vocab-1", "#{unit_page}#vocab-3")
+        # "Gizmo" sits between them.
+        expect(index).to include("#{unit_page}#vocab-2")
       end
 
       it 'produces the same output when run again' do

--- a/utilities/specs/content_anchors_spec.rb
+++ b/utilities/specs/content_anchors_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+# Drives the in-page anchors that let a generated summary page link back to the
+# exact box it copied, rather than to the top of the source page.
+#
+#   bundle exec rspec utilities/specs/content_anchors_spec.rb
+#
+# Curriculum pages are hand-written HTML with no build step, so their IDs are
+# assigned in the browser -- llab.addContentAnchors for vocab and exam boxes,
+# multiplechoice.js for self-check questions. The build tools count the same
+# boxes the same way (see utilities/build-tools/{vocab,selfcheck}.rb), and
+# nothing checks that agreement but a spec that follows a real link.
+
+require_relative 'spec_helper'
+
+UNIT_2_PARAMS = '?topic=nyc_bjc/2-conditionals-abstraction.topic&course=bjc4nyc.html'
+UNIT_2_PAGES = '/bjc-r/cur/programming/2-complexity'
+# Two vocab boxes, one exam box, two self-checks.
+GUESSING_GAME = "#{UNIT_2_PAGES}/1-variables-games/1-number-guessing-game.html#{UNIT_2_PARAMS}".freeze
+# One vocab box, two exam boxes, one self-check -- a different shape, and later
+# in the same unit, so unit-wide numbering would not start it back at 1.
+CHOOSING_AVATAR = "#{UNIT_2_PAGES}/1-variables-games/5-choosing-avatar.html#{UNIT_2_PARAMS}".freeze
+VOCAB_SUMMARY = "#{UNIT_2_PAGES}/unit-2-vocab.html#{UNIT_2_PARAMS}".freeze
+
+RSpec.describe 'content anchors', :js, driver: :chrome_headless_short, type: :feature do
+  # Capybara's `visit` returns once the document is complete, but the scroll
+  # runs on "load" and the self-checks are built on DOM ready, so the page
+  # settles a beat later.
+  def wait_for(description, timeout: 10)
+    deadline = Time.now + timeout
+    loop do
+      result = yield
+      return result if result
+      raise "Timed out after #{timeout}s waiting for #{description}" if Time.now > deadline
+
+      sleep 0.1
+    end
+  end
+
+  # Every box llab.addContentAnchors or multiplechoice.js numbered.
+  def anchor_ids
+    page.evaluate_script("Array.from(document.querySelectorAll('.anchor-target')).map(el => el.id)")
+  end
+
+  def scroll_y
+    page.evaluate_script('window.scrollY')
+  end
+
+  # How far below the top of the viewport the box sits, once scrolled.
+  def distance_from_viewport_top(selector)
+    page.evaluate_script("document.querySelector('#{selector}').getBoundingClientRect().top")
+  end
+
+  def navbar_bottom
+    page.evaluate_script("document.querySelector('.llab-nav').getBoundingClientRect().bottom")
+  end
+
+  def wait_for_anchors(*ids)
+    ids.each { |id| expect(page).to have_css("##{id}", visible: :all, wait: 15) }
+  end
+
+  # Wait until SELECTOR has been scrolled up near the top of the window. Not
+  # "until the page has scrolled at all": the nav and the bottom bar are added
+  # asynchronously and nudge the page a few pixels on their own, which is
+  # enough to satisfy a scrollY check well before the anchor is honored.
+  def wait_until_scrolled_to(selector)
+    wait_for("#{selector} to be scrolled into view") do
+      distance_from_viewport_top(selector) < 300
+    end
+  end
+
+  describe 'numbering' do
+    it 'numbers each kind of box from 1, per page' do
+      visit GUESSING_GAME
+      wait_for_anchors('vocab-2', 'exam-1', 'self-check-2')
+
+      expect(anchor_ids).to match_array(%w[vocab-1 vocab-2 exam-1 self-check-1 self-check-2])
+    end
+
+    it 'starts back at 1 on the next page of the same unit' do
+      visit CHOOSING_AVATAR
+      wait_for_anchors('vocab-1', 'exam-2', 'self-check-1')
+
+      expect(anchor_ids).to match_array(%w[vocab-1 exam-1 exam-2 self-check-1])
+    end
+
+    it 'numbers the boxes of a generated summary page too' do
+      visit VOCAB_SUMMARY
+      wait_for_anchors('vocab-1')
+
+      # The vocab index links to a term by its place on this page, so the
+      # numbering has to run past the boxes of every source page it collected.
+      expect(anchor_ids.length).to eq(page.all('.vocab.summaryBox', visible: :all).length)
+      expect(anchor_ids).to include('vocab-1', 'vocab-2')
+    end
+  end
+
+  describe 'scrolling' do
+    it 'scrolls to the box named by the URL fragment' do
+      visit "#{GUESSING_GAME}#vocab-2"
+      wait_for_anchors('vocab-2')
+
+      wait_until_scrolled_to('#vocab-2')
+      expect(scroll_y).to be > 300
+    end
+
+    it 'leaves the box clear of the fixed navbar' do
+      visit "#{GUESSING_GAME}#vocab-2"
+      wait_for_anchors('vocab-2')
+      wait_until_scrolled_to('#vocab-2')
+
+      expect(distance_from_viewport_top('#vocab-2')).to be >= navbar_bottom
+    end
+
+    it 'scrolls to a self-check, which exists only once quiz.js has built it' do
+      visit "#{GUESSING_GAME}#self-check-2"
+      wait_for_anchors('self-check-2')
+
+      wait_until_scrolled_to('#self-check-2')
+      expect(distance_from_viewport_top('#self-check-2')).to be >= navbar_bottom
+    end
+
+    it 'stays at the top when the URL names no box' do
+      visit GUESSING_GAME
+      wait_for_anchors('vocab-2')
+
+      expect(scroll_y).to eq(0)
+    end
+
+    it 'scrolls when only the fragment changes' do
+      visit GUESSING_GAME
+      wait_for_anchors('vocab-2')
+      expect(scroll_y).to eq(0)
+
+      page.execute_script("location.hash = 'vocab-2'")
+
+      wait_until_scrolled_to('#vocab-2')
+      expect(distance_from_viewport_top('#vocab-2')).to be >= navbar_bottom
+    end
+
+    it 'starts a dynamic page load at the top when it names no box' do
+      visit "#{GUESSING_GAME}#vocab-2"
+      wait_for_anchors('vocab-2')
+      wait_until_scrolled_to('#vocab-2')
+
+      find('.llab-nav .js-nextPageLink:not(.d-none)', wait: 15).click
+
+      wait_for('the next page to render') { page.evaluate_script('location.hash') == '' }
+      wait_for('the new page to settle') { scroll_y.zero? }
+      expect(scroll_y).to eq(0)
+    end
+
+    # Going back to a page that was reached by a summary backlink: the loader
+    # rebuilds it rather than restoring it, so the anchor has to be applied
+    # again or the reader loses their place.
+    it 'returns to the box when going back to an anchored page' do
+      visit "#{GUESSING_GAME}#vocab-2"
+      wait_for_anchors('vocab-2')
+      wait_until_scrolled_to('#vocab-2')
+      find('.llab-nav .js-nextPageLink:not(.d-none)', wait: 15).click
+      wait_for('the next page to render') { page.evaluate_script('location.hash') == '' }
+
+      page.go_back
+
+      wait_for_anchors('vocab-2')
+      wait_until_scrolled_to('#vocab-2')
+      expect(distance_from_viewport_top('#vocab-2')).to be >= navbar_bottom
+    end
+  end
+
+  # The point of the whole exercise: a link the build tools wrote, followed in a
+  # browser, landing on the box whose text the summary page copied.
+  describe 'a summary page backlink' do
+    it 'lands on the box the summary copied, not merely on the page' do
+      visit VOCAB_SUMMARY
+      link = find("a[href*='1-number-guessing-game.html'][href$='#vocab-2']", wait: 15)
+      summary_box = link.find(:xpath, './ancestor::div[contains(@class, "summaryBox")]')
+      copied_term = summary_box.first('strong', minimum: 1).text
+
+      link.click
+
+      wait_for_anchors('vocab-2')
+      wait_until_scrolled_to('#vocab-2')
+      expect(find('#vocab-2', visible: :all).first('strong', minimum: 1).text).to eq(copied_term)
+      # ...and the box the link used to land on says something else, so the
+      # assertion above would notice if the anchor were dropped.
+      expect(find('#vocab-1', visible: :all).first('strong', minimum: 1).text)
+        .not_to eq(copied_term)
+    end
+  end
+end

--- a/utilities/specs/self_check_feedback_spec.rb
+++ b/utilities/specs/self_check_feedback_spec.rb
@@ -120,3 +120,93 @@ def self_check_feedback_examples(url)
 end
 
 SELF_CHECK_PAGES.each { |url| self_check_feedback_examples(url) }
+
+# The one question the examples below work with; marked from JS by
+# stage_middle_question.
+TARGET_QUESTION = '.MultipleChoice.Question.js-spec-target'
+
+# Checking an answer moves focus off the Check Answer button, which is disabled
+# at that moment and would otherwise strand keyboard focus on <body>. Focusing
+# a button also scrolls it into view, which yanked the page out from under a
+# student mid-question on anything but a very tall window.
+RSpec.describe 'checking an answer', :js, driver: :chrome_headless_short, type: :feature do
+  # Everything below is driven through JS rather than through Capybara, which
+  # scrolls an element into view before clicking it -- the very thing being
+  # measured here.
+  #
+  # Picks a question in the middle of the page and answers it.
+  def stage_middle_question
+    page.execute_script(<<~JS)
+      var questions = document.querySelectorAll('.MultipleChoice.Question');
+      var question = questions[Math.floor(questions.length / 2)];
+      question.classList.add('js-spec-target');
+      question.querySelector('input[type=radio], input[type=checkbox]').click();
+    JS
+  end
+
+  # Puts the reader partway through the question, with its buttons just below
+  # the bottom of the window. That is the situation the fix is about: focusing
+  # a button there has somewhere to scroll to, and scrolling loses their place.
+  def scroll_buttons_just_below_the_fold
+    page.execute_script(<<~JS)
+      var button = document.querySelector('#{TARGET_QUESTION} .tryAgainButton');
+      var bottom = button.getBoundingClientRect().bottom + window.scrollY;
+      window.scrollTo(0, bottom - window.innerHeight - 60);
+    JS
+  end
+
+  def check_answer
+    page.execute_script("document.querySelector('#{TARGET_QUESTION} .checkAnswerButton').click()")
+  end
+
+  def try_again_offscreen?
+    page.evaluate_script(
+      "document.querySelector('#{TARGET_QUESTION} .tryAgainButton')" \
+      '.getBoundingClientRect().bottom > window.innerHeight'
+    )
+  end
+
+  # Images above the question keep loading for a moment after it is scrolled
+  # to, and Chrome's scroll anchoring moves the page along with them. Read the
+  # position only once it has stopped changing on its own.
+  def settled_scroll_position
+    previous = nil
+    20.times do
+      current = page.evaluate_script('window.scrollY')
+      return current if current == previous
+
+      previous = current
+      sleep 0.25
+    end
+    raise 'the page never stopped scrolling on its own'
+  end
+
+  before do
+    visit SELF_CHECK_PAGES.first
+    # find, not expect: waits the same way, but a before hook is no place for
+    # an assertion.
+    find('.MultipleChoice.Question .checkAnswerButton', match: :first, wait: 15)
+    stage_middle_question
+    settled_scroll_position # let the page finish moving before moving it ourselves
+    scroll_buttons_just_below_the_fold
+  end
+
+  it 'leaves the page where the student left it' do
+    before_scroll = settled_scroll_position
+    # Without this the question would already be fully on screen, and focusing
+    # its buttons would scroll nothing whatever the code did.
+    expect(try_again_offscreen?).to be(true)
+
+    check_answer
+
+    expect(page).to have_css("#{TARGET_QUESTION} .option-feedback", visible: :visible, text: /\S/, wait: 5)
+    expect(page.evaluate_script('window.scrollY')).to be_within(5).of(before_scroll)
+  end
+
+  it 'still moves focus to Try Again, off the disabled Check Answer button' do
+    check_answer
+
+    expect(page).to have_css("#{TARGET_QUESTION} .option-feedback", visible: :visible, text: /\S/, wait: 5)
+    expect(page.evaluate_script('document.activeElement.className')).to include('tryAgainButton')
+  end
+end

--- a/utilities/specs/spec_helper.rb
+++ b/utilities/specs/spec_helper.rb
@@ -47,6 +47,18 @@ Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 
+# The same browser in a window a student might actually have. Anything that
+# measures scrolling needs this: in the 4000px-tall window above, most
+# curriculum pages fit on screen whole and never scroll at all.
+# Select it per example group with `driver: :chrome_headless_short`.
+Capybara.register_driver :chrome_headless_short do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  %w[--headless --no-sandbox --disable-dev-shm-usage --window-size=1280,800]
+    .each { |argument| options.add_argument(argument) }
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
+
 # Change default_driver to :selenium_chrome if you want to actually see the tests running in a browser locally.
 # Should be :chrome_headless in CI though.
 Capybara.default_driver = :chrome_headless


### PR DESCRIPTION
## Fix anchor navigation for vocab, self-check, and exam content

Summary page backlinks previously used unit-wide incrementing IDs (`#box105`) that were never written onto curriculum pages, so every link silently dropped users at the top of the page. This PR replaces that scheme with per-page, per-type anchors (`#vocab-1`, `#self-check-1`, `#exam-1`) applied client-side, and ensures the browser scrolls to the correct position after dynamic content is built.

## Changes

**Anchor ID scheme**
- Replaced unit-wide `#boxN` anchors with per-page, per-type IDs: `#vocab-N`, `#self-check-N`, `#exam-N` (counting from 1, resetting per page)
- IDs are applied in the browser via `llab.addContentAnchors` (curriculum pages) and `multiplechoice.js` (self-check questions built from `.assessment-data`)
- No `id=` attributes are written into HTML by the build tools — pure JS assignment

**Scroll behavior**
- Added `llab.scrollToAnchor` which re-runs fragment lookup after the page and dynamic content are fully built, since the browser resolves `#anchor` targets before IDs exist
- Fires on `window load`, `hashchange`, and dynamic navigation; same-page `#anchor` clicks no longer trigger a full SPA re-fetch
- Scroll offset accounts for the navbar height (`:target` scroll-margin doesn't apply to IDs assigned post-navigation)

**Build tool output**
- All generated summary pages (vocab, self-check, exam reference) updated to emit `#type-N` fragment links instead of `#boxN`

**Bug fixes**
- Fixed 25 broken summary redirect stubs that pointed to non-existent filenames; all now resolve to correct URLs with hash preserved
- Removed redundant inline `Gifffer()` calls on two pages that caused `Gifffer is not defined` console errors when the library wasn't loaded
- Fixed unwanted scroll-into-view when clicking "Check Answer" in quizzes by using `focus({ preventScroll: true })`
- Removed focus ring on vocab/exam/self-check boxes (programmatic scroll targets shouldn't show a visible focus indicator)

## Visual Changes

- [Self-check anchor navigation](https://www.superconductor.com/ticket_implementations/hQTzPchQwfqP/artifacts/R6bQDfjddkmp)
- [Vocab anchor navigation](https://www.superconductor.com/ticket_implementations/hQTzPchQwfqP/artifacts/j9JBdGGg9WG9)

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/ppGCgfCtPmTQ/implementations/hQTzPchQwfqP) | [App Preview](https://www.superconductor.com/tickets/ppGCgfCtPmTQ/implementations/hQTzPchQwfqP/preview) | [Guided Review](https://www.superconductor.com/tickets/ppGCgfCtPmTQ/implementations/hQTzPchQwfqP?tab=guided_review)

<!-- created-by-superconductor -->