### PR TITLE
Convert legacy images to accessible SVG format

### DIFF
--- a/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html
+++ b/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.es.html
@@ -44,7 +44,7 @@
         <p>World Wide Web ha crecido mucho más allá de su propósito original, que era el intercambio rápido y fácil de información dentro de la comunidad científica. La expansión de la Web para incluir cosas como compras en línea y blogs personales fue una <em>consecuencia no deseada</em> de la tecnología.</p>
 
         <div class="ap-standard">CSN-1.B.1 ("open" part), CSN-1.E.1</div>
-        <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" />
+        <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.es.svg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" />
         <h3>¿Cómo funciona Internet?</h3>
         <p>
             Internet es una red masiva de computadoras que facilitan la comunicación en todo el mundo. Funciona porque está diseñada para ser tolerante a fallas (capaz de funcionar incluso si falla parte de la red) y utiliza protocolos (un tipo de abstracción) para enrutar y transmitir datos:

--- a/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html
+++ b/cur/programming/4-internet/1-reliable-communication/1-what-is-internet.html
@@ -54,7 +54,7 @@
         <p>The World Wide Web has grown far beyond its original purpose, which was rapid and easy exchange of information within the scientific community. The expansion of the Web to include things like online shopping and personal blogs was an <em>unintended consequence</em> of the technology.</p>
 
         <div class="ap-standard">CSN-1.B.1 ("open" part), CSN-1.E.1</div>
-        <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" title="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" />
+        <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple redundant connections among the nodes between them" title="graph of a network with a sender and a receiver at each end and multiple redundant connections among the nodes between them" />
         <h3>How Does the Internet Work?</h3>
         <p>
             The Internet is a massive network of computers that facilitate communication around the globe. It works because it's engineered to be fault-tolerant (capable of working even if some of the network breaks down) and uses protocols (a type of abstraction) for routing and transmitting data:

--- a/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html
+++ b/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.es.html
@@ -50,7 +50,7 @@
                     <div class="assessment-data" type="multiplechoice" identifier="What is the fewest number of nodes?"
                         hasinlinefeedback="true" maxchoices="1" responseIdentifier="ri1" shuffle="false">
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" /> En este modelo de red, ¿cuál es el número <em>mínimo</em> de nodos (puntos de conexión) que pueden dejar de funcionar antes de que el emisor y el receptor no puedan comunicarse? (Aparte del remitente o el receptor, por supuesto).
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.es.svg" height="250px" alt="Diagrama de red: un emisor en la parte superior y un receptor en la parte inferior están conectados a través de diez nodos intermedios, llamados aquí A a J, con enlaces redundantes. Los enlaces son: Emisor a A, Emisor a B, Emisor a D, A a D, A a E, B a C, B a F, B a H, C a D, D a G, D a H, E a J, F a H, F a I, G a J, H a I, H a J, H a Receptor, e I a Receptor." title="Diagrama de red con conexiones redundantes entre el emisor y el receptor" /> En este modelo de red, ¿cuál es el número <em>mínimo</em> de nodos (puntos de conexión) que pueden dejar de funcionar antes de que el emisor y el receptor no puedan comunicarse? (Aparte del remitente o el receptor, por supuesto).
                         </div>
                         <div class="choice" identifier="c1">
                             <div class="text">1</div>
@@ -91,7 +91,7 @@
                     <div class="assessment-data" type="multiplechoice" identifier="What is the maximum that can fail?"
                         hasinlinefeedback="true" maxchoices="1" responseIdentifier="ri2" shuffle="false">
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" /> En el mismo modelo de red, ¿cuál es el número <em>máximo</em> de nodos que pueden fallar y aun así permitir que el remitente y el receptor se comuniquen?
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.es.svg" height="250px" alt="Diagrama de red: un emisor en la parte superior y un receptor en la parte inferior están conectados a través de diez nodos intermedios, llamados aquí A a J, con enlaces redundantes. Los enlaces son: Emisor a A, Emisor a B, Emisor a D, A a D, A a E, B a C, B a F, B a H, C a D, D a G, D a H, E a J, F a H, F a I, G a J, H a I, H a J, H a Receptor, e I a Receptor." title="Diagrama de red con conexiones redundantes entre el emisor y el receptor" /> En el mismo modelo de red, ¿cuál es el número <em>máximo</em> de nodos que pueden fallar y aun así permitir que el remitente y el receptor se comuniquen?
                         </div>
                         <div class="choice" identifier="c1">
                             <div class="text">10</div>

--- a/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html
+++ b/cur/programming/4-internet/1-reliable-communication/2-network-redundancy.html
@@ -51,7 +51,7 @@
                     <div class="assessment-data" type="multiplechoice" identifier="What is the fewest number of nodes?"
                         hasinlinefeedback="true" maxchoices="1" responseIdentifier="ri1" shuffle="false">
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" title="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" />
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg" height="250px" alt="Network diagram: a Sender at the top and a Receiver at the bottom are connected through ten intermediate nodes, called A through J here, with redundant links. The links are: Sender to A, Sender to B, Sender to D, A to D, A to E, B to C, B to F, B to H, C to D, D to G, D to H, E to J, F to H, F to I, G to J, H to I, H to J, H to Receiver, and I to Receiver." title="Network diagram with redundant connections between Sender and Receiver" />
                             In this model of a network, what is the <em>minimum</em> number of nodes (connection points) that can stop working before the sender and the receiver can't communicate? (Other than the sender or the receiver themselves, of course.)
                         </div>
                         <div class="choice" identifier="c1">
@@ -93,7 +93,7 @@
                     <div class="assessment-data" type="multiplechoice" identifier="What is the maximum that can fail?"
                         hasinlinefeedback="true" maxchoices="1" responseIdentifier="ri2" shuffle="false">
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" title="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" />
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg" height="250px" alt="Network diagram: a Sender at the top and a Receiver at the bottom are connected through ten intermediate nodes, called A through J here, with redundant links. The links are: Sender to A, Sender to B, Sender to D, A to D, A to E, B to C, B to F, B to H, C to D, D to G, D to H, E to J, F to H, F to I, G to J, H to I, H to J, H to Receiver, and I to Receiver." title="Network diagram with redundant connections between Sender and Receiver" />
                             In the same model network, what is the <em>maximum</em> number of nodes that can fail and still let Sender and Receiver communicate?
                         </div>
                         <div class="choice" identifier="c1">

--- a/cur/programming/4-internet/unit-4-self-check.es.html
+++ b/cur/programming/4-internet/unit-4-self-check.es.html
@@ -42,7 +42,7 @@
 </div>
 
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos"> En este modelo de red, ¿cuál es el número <em>mínimo</em> de nodos (puntos de conexión) que pueden dejar de funcionar antes de que el emisor y el receptor no puedan comunicarse? (Aparte del remitente o el receptor, por supuesto).
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.es.svg" height="250px" alt="Diagrama de red: un emisor en la parte superior y un receptor en la parte inferior están conectados a través de diez nodos intermedios, llamados aquí A a J, con enlaces redundantes. Los enlaces son: Emisor a A, Emisor a B, Emisor a D, A a D, A a E, B a C, B a F, B a H, C a D, D a G, D a H, E a J, F a H, F a I, G a J, H a I, H a J, H a Receptor, e I a Receptor." title="Diagrama de red con conexiones redundantes entre el emisor y el receptor"> En este modelo de red, ¿cuál es el número <em>mínimo</em> de nodos (puntos de conexión) que pueden dejar de funcionar antes de que el emisor y el receptor no puedan comunicarse? (Aparte del remitente o el receptor, por supuesto).
                         </div>
                         <div class="choice" identifier="c1">
                             <div class="text">1</div>
@@ -83,7 +83,7 @@
 </div>
 
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos" title="Gráfico de una red con un emisor y un receptor en cada extremo, y múltiples conexiones entre varios nodos entre ellos"> En el mismo modelo de red, ¿cuál es el número <em>máximo</em> de nodos que pueden fallar y aun así permitir que el remitente y el receptor se comuniquen?
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.es.svg" height="250px" alt="Diagrama de red: un emisor en la parte superior y un receptor en la parte inferior están conectados a través de diez nodos intermedios, llamados aquí A a J, con enlaces redundantes. Los enlaces son: Emisor a A, Emisor a B, Emisor a D, A a D, A a E, B a C, B a F, B a H, C a D, D a G, D a H, E a J, F a H, F a I, G a J, H a I, H a J, H a Receptor, e I a Receptor." title="Diagrama de red con conexiones redundantes entre el emisor y el receptor"> En el mismo modelo de red, ¿cuál es el número <em>máximo</em> de nodos que pueden fallar y aun así permitir que el remitente y el receptor se comuniquen?
                         </div>
                         <div class="choice" identifier="c1">
                             <div class="text">10</div>

--- a/cur/programming/4-internet/unit-4-self-check.html
+++ b/cur/programming/4-internet/unit-4-self-check.html
@@ -42,7 +42,7 @@
 </div>
 
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" title="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them">
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg" height="250px" alt="Network diagram: a Sender at the top and a Receiver at the bottom are connected through ten intermediate nodes, called A through J here, with redundant links. The links are: Sender to A, Sender to B, Sender to D, A to D, A to E, B to C, B to F, B to H, C to D, D to G, D to H, E to J, F to H, F to I, G to J, H to I, H to J, H to Receiver, and I to Receiver." title="Network diagram with redundant connections between Sender and Receiver">
                             In this model of a network, what is the <em>minimum</em> number of nodes (connection points) that can stop working before the sender and the receiver can't communicate? (Other than the sender or the receiver themselves, of course.)
                         </div>
                         <div class="choice" identifier="c1">
@@ -84,7 +84,7 @@
 </div>
 
                         <div class="prompt">
-                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg" height="250px" alt="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them" title="graph of a network with a sender and a receiver at each end and multiple connections among multiple notes between them">
+                            <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg" height="250px" alt="Network diagram: a Sender at the top and a Receiver at the bottom are connected through ten intermediate nodes, called A through J here, with redundant links. The links are: Sender to A, Sender to B, Sender to D, A to D, A to E, B to C, B to F, B to H, C to D, D to G, D to H, E to J, F to H, F to I, G to J, H to I, H to J, H to Receiver, and I to Receiver." title="Network diagram with redundant connections between Sender and Receiver">
                             In the same model network, what is the <em>maximum</em> number of nodes that can fail and still let Sender and Receiver communicate?
                         </div>
                         <div class="choice" identifier="c1">

--- a/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html
+++ b/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.es.html
@@ -297,12 +297,12 @@
                                 	<tr>
                                     	<td width="200">
                                             <ol style="list-style:upper-roman;" start="1">
-                                                <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.es.png" alt="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" title="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" /></li>
+                                                <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.es.svg" alt="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" title="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" /></li>
                                             </ol>
                                         </td>
                                         <td>
                                             <ol style="list-style:upper-roman;" start="2">
-                                                <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.es.png" alt="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" title="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" /></li>
+                                                <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.es.svg" alt="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" title="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" /></li>
                                             </ol>
                                         </td>
                                     </tr>

--- a/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html
+++ b/cur/programming/6-computers/1-abstraction/09-digital-logic-gates.html
@@ -307,12 +307,12 @@
                                 <tr>
                                     <td width="200">
                                         <ol style="list-style:upper-roman;" start="1">
-                                            <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.png" alt="logic gate diagram of (not ((T and F)) or (T and F))" title="logic gate diagram of (not ((T and F)) or (T and F))" /></li>
+                                            <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.svg" alt="logic gate diagram of (not ((T and F)) or (T and F))" title="logic gate diagram of (not ((T and F)) or (T and F))" /></li>
                                         </ol>
                                     </td>
                                     <td>
                                         <ol style="list-style:upper-roman;" start="2">
-                                            <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.png" alt="logic gate diagram of ((T or F) and (not (T or F)))" title="logic gate diagram of ((T or F) and (not (T or F)))" /></li>
+                                            <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.svg" alt="logic gate diagram of ((T or F) and (not (T or F)))" title="logic gate diagram of ((T or F) and (not (T or F)))" /></li>
                                         </ol>
                                     </td>
                                 </tr>

--- a/cur/programming/6-computers/unit-6-self-check.es.html
+++ b/cur/programming/6-computers/unit-6-self-check.es.html
@@ -152,12 +152,12 @@
                                 	<tr>
                                     	<td width="200">
                                             <ol style="list-style:upper-roman;" start="1">
-                                                <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.es.png" alt="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" title="diagrama de compuerta lógica de (no ((T y F)) o (T y F))"></li>
+                                                <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.es.svg" alt="diagrama de compuerta lógica de (no ((T y F)) o (T y F))" title="diagrama de compuerta lógica de (no ((T y F)) o (T y F))"></li>
                                             </ol>
                                         </td>
                                         <td>
                                             <ol style="list-style:upper-roman;" start="2">
-                                                <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.es.png" alt="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" title="diagrama de compuerta lógica de ((T o F) y (no (T o F)))"></li>
+                                                <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.es.svg" alt="diagrama de compuerta lógica de ((T o F) y (no (T o F)))" title="diagrama de compuerta lógica de ((T o F) y (no (T o F)))"></li>
                                             </ol>
                                         </td>
                                     </tr>

--- a/cur/programming/6-computers/unit-6-self-check.html
+++ b/cur/programming/6-computers/unit-6-self-check.html
@@ -151,12 +151,12 @@
                                 <tr>
                                     <td width="200">
                                         <ol style="list-style:upper-roman;" start="1">
-                                            <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.png" alt="logic gate diagram of (not ((T and F)) or (T and F))" title="logic gate diagram of (not ((T and F)) or (T and F))"></li>
+                                            <li><img class="inline noshadow" src="/bjc-r/img/6-computers/logic-gates-quiz-b.svg" alt="logic gate diagram of (not ((T and F)) or (T and F))" title="logic gate diagram of (not ((T and F)) or (T and F))"></li>
                                         </ol>
                                     </td>
                                     <td>
                                         <ol style="list-style:upper-roman;" start="2">
-                                            <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.png" alt="logic gate diagram of ((T or F) and (not (T or F)))" title="logic gate diagram of ((T or F) and (not (T or F)))"></li>
+                                            <li><img class="inline noshadow" align="bottom" src="/bjc-r/img/6-computers/logic-gates-quiz-a.svg" alt="logic gate diagram of ((T or F) and (not (T or F)))" title="logic gate diagram of ((T or F) and (not (T or F)))"></li>
                                         </ol>
                                     </td>
                                 </tr>

--- a/cur/teaching-guide/U4/lab-pages/1-reliable-communication.html
+++ b/cur/teaching-guide/U4/lab-pages/1-reliable-communication.html
@@ -101,7 +101,7 @@
               <li>
                 After students have worked through the questions on the lab page, you could use these
                 questions for a group discussion:
-                <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.jpg"
+                <img class="imageRight" src="/bjc-r/img/4-internet/redundant-2.svg"
                   alt="A network with the sender connected to the receiver via a multitude of nodes and routes demonstrating network redundancy"
                   title="A network with the sender connected to the receiver via a multitude of nodes and routes demonstrating network redundancy" />
                 <ul>

--- a/img/4-internet/redundant-2.es.svg
+++ b/img/4-internet/redundant-2.es.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="335" height="353" viewBox="0 0 335 353" role="img" aria-labelledby="rnet-title rnet-desc" id="rnet-root">
+  <title id="rnet-title">Una red redundante que conecta un emisor y un receptor a través de diez nodos intermedios</title>
+  <desc id="rnet-desc">Una red de computadoras dibujada como un grafo sobre un fondo negro. Un nodo emisor magenta en la parte superior y un nodo receptor magenta en la parte inferior están conectados a través de diez nodos intermedios azules, llamados aquí A a J, unidos por enlaces verdes. Los enlaces son: Emisor–A; Emisor–B; Emisor–D; A–D; A–E; B–C; B–F; B–H; C–D; D–G; D–H; E–J; F–H; F–I; G–J; H–I; H–J; H–Receptor; I–Receptor. Existen múltiples rutas entre el emisor y el receptor, de modo que la red puede seguir funcionando aunque fallen algunos nodos.</desc>
+  <defs>
+    <radialGradient id="rnet-nodefill" cx="0.4" cy="0.35" r="0.9">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.55" stop-color="#cfeafd"/>
+      <stop offset="1" stop-color="#8ecfef"/>
+    </radialGradient>
+    <filter id="rnet-soft" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="3.2"/>
+    </filter>
+  </defs>
+  <style>
+    .edge .halo { stroke: #4c7c1f; stroke-width: 5.5; stroke-linecap: round; }
+    .edge .core { stroke: #9be14e; stroke-width: 2; stroke-linecap: round; }
+    .edge, .node { transition: opacity 0.15s ease; }
+    .node { cursor: pointer; }
+    .node:focus { outline: none; }
+    .dimmed { opacity: 0.22; }
+    .node.lit .ring, .node:focus .ring { stroke: #ffffff; }
+    .label { font-family: Arial, Helvetica, sans-serif; font-size: 21px; fill: #ffffff; }
+  </style>
+  <rect x="0" y="0" width="335" height="353" fill="#000000"/>
+  <g id="rnet-edges">
+    <g class="edge" data-n="S A"><line class="halo" x1="86" y1="24" x2="224" y2="89"/><line class="core" x1="86" y1="24" x2="224" y2="89"/></g>
+    <g class="edge" data-n="S B"><line class="halo" x1="86" y1="24" x2="23" y2="101"/><line class="core" x1="86" y1="24" x2="23" y2="101"/></g>
+    <g class="edge" data-n="S D"><line class="halo" x1="86" y1="24" x2="146" y2="144"/><line class="core" x1="86" y1="24" x2="146" y2="144"/></g>
+    <g class="edge" data-n="A D"><line class="halo" x1="224" y1="89" x2="146" y2="144"/><line class="core" x1="224" y1="89" x2="146" y2="144"/></g>
+    <g class="edge" data-n="A E"><line class="halo" x1="224" y1="89" x2="309" y2="156"/><line class="core" x1="224" y1="89" x2="309" y2="156"/></g>
+    <g class="edge" data-n="B C"><line class="halo" x1="23" y1="101" x2="73" y2="102"/><line class="core" x1="23" y1="101" x2="73" y2="102"/></g>
+    <g class="edge" data-n="B F"><line class="halo" x1="23" y1="101" x2="55" y2="185"/><line class="core" x1="23" y1="101" x2="55" y2="185"/></g>
+    <g class="edge" data-n="B H"><line class="halo" x1="23" y1="101" x2="129" y2="233"/><line class="core" x1="23" y1="101" x2="129" y2="233"/></g>
+    <g class="edge" data-n="C D"><line class="halo" x1="73" y1="102" x2="146" y2="144"/><line class="core" x1="73" y1="102" x2="146" y2="144"/></g>
+    <g class="edge" data-n="D G"><line class="halo" x1="146" y1="144" x2="218" y2="204"/><line class="core" x1="146" y1="144" x2="218" y2="204"/></g>
+    <g class="edge" data-n="D H"><line class="halo" x1="146" y1="144" x2="129" y2="233"/><line class="core" x1="146" y1="144" x2="129" y2="233"/></g>
+    <g class="edge" data-n="E J"><line class="halo" x1="309" y1="156" x2="199" y2="301"/><line class="core" x1="309" y1="156" x2="199" y2="301"/></g>
+    <g class="edge" data-n="F H"><line class="halo" x1="55" y1="185" x2="129" y2="233"/><line class="core" x1="55" y1="185" x2="129" y2="233"/></g>
+    <g class="edge" data-n="F I"><line class="halo" x1="55" y1="185" x2="42" y2="276"/><line class="core" x1="55" y1="185" x2="42" y2="276"/></g>
+    <g class="edge" data-n="G J"><line class="halo" x1="218" y1="204" x2="199" y2="301"/><line class="core" x1="218" y1="204" x2="199" y2="301"/></g>
+    <g class="edge" data-n="H I"><line class="halo" x1="129" y1="233" x2="42" y2="276"/><line class="core" x1="129" y1="233" x2="42" y2="276"/></g>
+    <g class="edge" data-n="H J"><line class="halo" x1="129" y1="233" x2="199" y2="301"/><line class="core" x1="129" y1="233" x2="199" y2="301"/></g>
+    <g class="edge" data-n="H R"><line class="halo" x1="129" y1="233" x2="86" y2="329"/><line class="core" x1="129" y1="233" x2="86" y2="329"/></g>
+    <g class="edge" data-n="I R"><line class="halo" x1="42" y1="276" x2="86" y2="329"/><line class="core" x1="42" y1="276" x2="86" y2="329"/></g>
+  </g>
+  <g id="rnet-nodes">
+    <g class="node" data-n="S" tabindex="0" aria-label="Emisor — conectado con A, B y D"><title>Emisor — conectado con A, B y D</title><circle cx="86" cy="24" r="11" fill="#f03489" opacity="0.75" filter="url(#rnet-soft)"/><circle class="ring" cx="86" cy="24" r="9.5" fill="#f03489" stroke="none" stroke-width="2"/></g>
+    <g class="node" data-n="A" tabindex="0" aria-label="Nodo A (arriba a la derecha) — conectado con Emisor, D y E"><title>Nodo A (arriba a la derecha) — conectado con Emisor, D y E</title><circle cx="224" cy="89" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="224" cy="89" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="B" tabindex="0" aria-label="Nodo B (arriba en el extremo izquierdo) — conectado con Emisor, C, F y H"><title>Nodo B (arriba en el extremo izquierdo) — conectado con Emisor, C, F y H</title><circle cx="23" cy="101" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="23" cy="101" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="C" tabindex="0" aria-label="Nodo C (arriba a la izquierda) — conectado con B y D"><title>Nodo C (arriba a la izquierda) — conectado con B y D</title><circle cx="73" cy="102" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="73" cy="102" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="D" tabindex="0" aria-label="Nodo D (al centro) — conectado con Emisor, A, C, G y H"><title>Nodo D (al centro) — conectado con Emisor, A, C, G y H</title><circle cx="146" cy="144" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="146" cy="144" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="E" tabindex="0" aria-label="Nodo E (en el extremo derecho) — conectado con A y J"><title>Nodo E (en el extremo derecho) — conectado con A y J</title><circle cx="309" cy="156" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="309" cy="156" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="F" tabindex="0" aria-label="Nodo F (al centro a la izquierda) — conectado con B, H y I"><title>Nodo F (al centro a la izquierda) — conectado con B, H y I</title><circle cx="55" cy="185" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="55" cy="185" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="G" tabindex="0" aria-label="Nodo G (al centro a la derecha) — conectado con D y J"><title>Nodo G (al centro a la derecha) — conectado con D y J</title><circle cx="218" cy="204" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="218" cy="204" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="H" tabindex="0" aria-label="Nodo H (abajo al centro) — conectado con B, D, F, I, J y Receptor"><title>Nodo H (abajo al centro) — conectado con B, D, F, I, J y Receptor</title><circle cx="129" cy="233" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="129" cy="233" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="I" tabindex="0" aria-label="Nodo I (abajo a la izquierda) — conectado con F, H y Receptor"><title>Nodo I (abajo a la izquierda) — conectado con F, H y Receptor</title><circle cx="42" cy="276" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="42" cy="276" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="J" tabindex="0" aria-label="Nodo J (abajo a la derecha) — conectado con E, G y H"><title>Nodo J (abajo a la derecha) — conectado con E, G y H</title><circle cx="199" cy="301" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="199" cy="301" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="R" tabindex="0" aria-label="Receptor — conectado con H y I"><title>Receptor — conectado con H y I</title><circle cx="86" cy="329" r="11" fill="#f03489" opacity="0.75" filter="url(#rnet-soft)"/><circle class="ring" cx="86" cy="329" r="9.5" fill="#f03489" stroke="none" stroke-width="2"/></g>
+  </g>
+  <text class="label" x="103" y="32">Emisor</text>
+  <text class="label" x="103" y="337">Receptor</text>
+  <script><![CDATA[
+    // Progressive enhancement: when this SVG is opened directly, inlined, or
+    // embedded with <object>, hovering or keyboard-focusing a node highlights
+    // that node, its links, and its neighbors. Inside an <img> element,
+    // scripts never run and the static image is shown unchanged.
+    (function () {
+      var root = document.getElementById('rnet-root');
+      if (!root) { return; }
+      var nodes = root.querySelectorAll('.node');
+      var edges = root.querySelectorAll('.edge');
+      function setHighlight(id) {
+        var neighbors = {};
+        edges.forEach(function (e) {
+          var ends = e.getAttribute('data-n').split(' ');
+          var incident = id !== null && ends.indexOf(id) !== -1;
+          e.classList.toggle('dimmed', id !== null && !incident);
+          if (incident) {
+            neighbors[ends[0]] = true;
+            neighbors[ends[1]] = true;
+          }
+        });
+        nodes.forEach(function (n) {
+          var nid = n.getAttribute('data-n');
+          n.classList.toggle('dimmed', id !== null && !neighbors[nid]);
+          n.classList.toggle('lit', nid === id);
+        });
+      }
+      nodes.forEach(function (n) {
+        var id = n.getAttribute('data-n');
+        n.addEventListener('mouseenter', function () { setHighlight(id); });
+        n.addEventListener('focus', function () { setHighlight(id); });
+        n.addEventListener('mouseleave', function () { setHighlight(null); });
+        n.addEventListener('blur', function () { setHighlight(null); });
+      });
+    })();
+  ]]></script>
+</svg>

--- a/img/4-internet/redundant-2.svg
+++ b/img/4-internet/redundant-2.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="335" height="353" viewBox="0 0 335 353" role="img" aria-labelledby="rnet-title rnet-desc" id="rnet-root">
+  <title id="rnet-title">A redundant network connecting a Sender and a Receiver through ten intermediate nodes</title>
+  <desc id="rnet-desc">A computer network drawn as a graph on a black background. A magenta Sender node at the top and a magenta Receiver node at the bottom are connected through ten blue intermediate nodes, called A through J here, joined by green links. The links are: Sender–A; Sender–B; Sender–D; A–D; A–E; B–C; B–F; B–H; C–D; D–G; D–H; E–J; F–H; F–I; G–J; H–I; H–J; H–Receiver; I–Receiver. There are multiple routes between the Sender and the Receiver, so the network can keep working even when some nodes fail.</desc>
+  <defs>
+    <radialGradient id="rnet-nodefill" cx="0.4" cy="0.35" r="0.9">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.55" stop-color="#cfeafd"/>
+      <stop offset="1" stop-color="#8ecfef"/>
+    </radialGradient>
+    <filter id="rnet-soft" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="3.2"/>
+    </filter>
+  </defs>
+  <style>
+    .edge .halo { stroke: #4c7c1f; stroke-width: 5.5; stroke-linecap: round; }
+    .edge .core { stroke: #9be14e; stroke-width: 2; stroke-linecap: round; }
+    .edge, .node { transition: opacity 0.15s ease; }
+    .node { cursor: pointer; }
+    .node:focus { outline: none; }
+    .dimmed { opacity: 0.22; }
+    .node.lit .ring, .node:focus .ring { stroke: #ffffff; }
+    .label { font-family: Arial, Helvetica, sans-serif; font-size: 21px; fill: #ffffff; }
+  </style>
+  <rect x="0" y="0" width="335" height="353" fill="#000000"/>
+  <g id="rnet-edges">
+    <g class="edge" data-n="S A"><line class="halo" x1="86" y1="24" x2="224" y2="89"/><line class="core" x1="86" y1="24" x2="224" y2="89"/></g>
+    <g class="edge" data-n="S B"><line class="halo" x1="86" y1="24" x2="23" y2="101"/><line class="core" x1="86" y1="24" x2="23" y2="101"/></g>
+    <g class="edge" data-n="S D"><line class="halo" x1="86" y1="24" x2="146" y2="144"/><line class="core" x1="86" y1="24" x2="146" y2="144"/></g>
+    <g class="edge" data-n="A D"><line class="halo" x1="224" y1="89" x2="146" y2="144"/><line class="core" x1="224" y1="89" x2="146" y2="144"/></g>
+    <g class="edge" data-n="A E"><line class="halo" x1="224" y1="89" x2="309" y2="156"/><line class="core" x1="224" y1="89" x2="309" y2="156"/></g>
+    <g class="edge" data-n="B C"><line class="halo" x1="23" y1="101" x2="73" y2="102"/><line class="core" x1="23" y1="101" x2="73" y2="102"/></g>
+    <g class="edge" data-n="B F"><line class="halo" x1="23" y1="101" x2="55" y2="185"/><line class="core" x1="23" y1="101" x2="55" y2="185"/></g>
+    <g class="edge" data-n="B H"><line class="halo" x1="23" y1="101" x2="129" y2="233"/><line class="core" x1="23" y1="101" x2="129" y2="233"/></g>
+    <g class="edge" data-n="C D"><line class="halo" x1="73" y1="102" x2="146" y2="144"/><line class="core" x1="73" y1="102" x2="146" y2="144"/></g>
+    <g class="edge" data-n="D G"><line class="halo" x1="146" y1="144" x2="218" y2="204"/><line class="core" x1="146" y1="144" x2="218" y2="204"/></g>
+    <g class="edge" data-n="D H"><line class="halo" x1="146" y1="144" x2="129" y2="233"/><line class="core" x1="146" y1="144" x2="129" y2="233"/></g>
+    <g class="edge" data-n="E J"><line class="halo" x1="309" y1="156" x2="199" y2="301"/><line class="core" x1="309" y1="156" x2="199" y2="301"/></g>
+    <g class="edge" data-n="F H"><line class="halo" x1="55" y1="185" x2="129" y2="233"/><line class="core" x1="55" y1="185" x2="129" y2="233"/></g>
+    <g class="edge" data-n="F I"><line class="halo" x1="55" y1="185" x2="42" y2="276"/><line class="core" x1="55" y1="185" x2="42" y2="276"/></g>
+    <g class="edge" data-n="G J"><line class="halo" x1="218" y1="204" x2="199" y2="301"/><line class="core" x1="218" y1="204" x2="199" y2="301"/></g>
+    <g class="edge" data-n="H I"><line class="halo" x1="129" y1="233" x2="42" y2="276"/><line class="core" x1="129" y1="233" x2="42" y2="276"/></g>
+    <g class="edge" data-n="H J"><line class="halo" x1="129" y1="233" x2="199" y2="301"/><line class="core" x1="129" y1="233" x2="199" y2="301"/></g>
+    <g class="edge" data-n="H R"><line class="halo" x1="129" y1="233" x2="86" y2="329"/><line class="core" x1="129" y1="233" x2="86" y2="329"/></g>
+    <g class="edge" data-n="I R"><line class="halo" x1="42" y1="276" x2="86" y2="329"/><line class="core" x1="42" y1="276" x2="86" y2="329"/></g>
+  </g>
+  <g id="rnet-nodes">
+    <g class="node" data-n="S" tabindex="0" aria-label="Sender — linked to A, B and D"><title>Sender — linked to A, B and D</title><circle cx="86" cy="24" r="11" fill="#f03489" opacity="0.75" filter="url(#rnet-soft)"/><circle class="ring" cx="86" cy="24" r="9.5" fill="#f03489" stroke="none" stroke-width="2"/></g>
+    <g class="node" data-n="A" tabindex="0" aria-label="Node A (upper right) — linked to Sender, D and E"><title>Node A (upper right) — linked to Sender, D and E</title><circle cx="224" cy="89" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="224" cy="89" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="B" tabindex="0" aria-label="Node B (upper far left) — linked to Sender, C, F and H"><title>Node B (upper far left) — linked to Sender, C, F and H</title><circle cx="23" cy="101" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="23" cy="101" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="C" tabindex="0" aria-label="Node C (upper left) — linked to B and D"><title>Node C (upper left) — linked to B and D</title><circle cx="73" cy="102" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="73" cy="102" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="D" tabindex="0" aria-label="Node D (center) — linked to Sender, A, C, G and H"><title>Node D (center) — linked to Sender, A, C, G and H</title><circle cx="146" cy="144" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="146" cy="144" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="E" tabindex="0" aria-label="Node E (far right) — linked to A and J"><title>Node E (far right) — linked to A and J</title><circle cx="309" cy="156" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="309" cy="156" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="F" tabindex="0" aria-label="Node F (middle left) — linked to B, H and I"><title>Node F (middle left) — linked to B, H and I</title><circle cx="55" cy="185" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="55" cy="185" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="G" tabindex="0" aria-label="Node G (middle right) — linked to D and J"><title>Node G (middle right) — linked to D and J</title><circle cx="218" cy="204" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="218" cy="204" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="H" tabindex="0" aria-label="Node H (lower center) — linked to B, D, F, I, J and Receiver"><title>Node H (lower center) — linked to B, D, F, I, J and Receiver</title><circle cx="129" cy="233" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="129" cy="233" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="I" tabindex="0" aria-label="Node I (lower left) — linked to F, H and Receiver"><title>Node I (lower left) — linked to F, H and Receiver</title><circle cx="42" cy="276" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="42" cy="276" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="J" tabindex="0" aria-label="Node J (lower right) — linked to E, G and H"><title>Node J (lower right) — linked to E, G and H</title><circle cx="199" cy="301" r="12" fill="#19c6f0" opacity="0.8" filter="url(#rnet-soft)"/><circle class="ring" cx="199" cy="301" r="8.5" fill="url(#rnet-nodefill)" stroke="#00a5c8" stroke-width="3"/></g>
+    <g class="node" data-n="R" tabindex="0" aria-label="Receiver — linked to H and I"><title>Receiver — linked to H and I</title><circle cx="86" cy="329" r="11" fill="#f03489" opacity="0.75" filter="url(#rnet-soft)"/><circle class="ring" cx="86" cy="329" r="9.5" fill="#f03489" stroke="none" stroke-width="2"/></g>
+  </g>
+  <text class="label" x="103" y="32">Sender</text>
+  <text class="label" x="103" y="337">Receiver</text>
+  <script><![CDATA[
+    // Progressive enhancement: when this SVG is opened directly, inlined, or
+    // embedded with <object>, hovering or keyboard-focusing a node highlights
+    // that node, its links, and its neighbors. Inside an <img> element,
+    // scripts never run and the static image is shown unchanged.
+    (function () {
+      var root = document.getElementById('rnet-root');
+      if (!root) { return; }
+      var nodes = root.querySelectorAll('.node');
+      var edges = root.querySelectorAll('.edge');
+      function setHighlight(id) {
+        var neighbors = {};
+        edges.forEach(function (e) {
+          var ends = e.getAttribute('data-n').split(' ');
+          var incident = id !== null && ends.indexOf(id) !== -1;
+          e.classList.toggle('dimmed', id !== null && !incident);
+          if (incident) {
+            neighbors[ends[0]] = true;
+            neighbors[ends[1]] = true;
+          }
+        });
+        nodes.forEach(function (n) {
+          var nid = n.getAttribute('data-n');
+          n.classList.toggle('dimmed', id !== null && !neighbors[nid]);
+          n.classList.toggle('lit', nid === id);
+        });
+      }
+      nodes.forEach(function (n) {
+        var id = n.getAttribute('data-n');
+        n.addEventListener('mouseenter', function () { setHighlight(id); });
+        n.addEventListener('focus', function () { setHighlight(id); });
+        n.addEventListener('mouseleave', function () { setHighlight(null); });
+        n.addEventListener('blur', function () { setHighlight(null); });
+      });
+    })();
+  ]]></script>
+</svg>

--- a/img/6-computers/logic-gates-quiz-a.es.svg
+++ b/img/6-computers/logic-gates-quiz-a.es.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="308" viewBox="0 0 116 308" role="img" aria-labelledby="lgqa-title lgqa-desc">
+  <title id="lgqa-title">Diagrama de compuertas lógicas de ((T o F) y (no (T o F)))</title>
+  <desc id="lgqa-desc">Las entradas T y F alimentan una compuerta O cuya salida alimenta una compuerta NO. Un segundo par de entradas, T y F, alimenta una segunda compuerta O. Las salidas de la compuerta NO y de la segunda compuerta O alimentan una compuerta Y, que produce la salida.</desc>
+  <defs>
+    <marker id="lgqa-arrow" markerWidth="8" markerHeight="8" refX="4.5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#000"/>
+    </marker>
+  </defs>
+  <style>
+    .wire { stroke: #000; stroke-width: 1.5; fill: none; }
+    .box { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    .input { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    text { font-family: 'Courier New', Courier, monospace; font-weight: bold; font-size: 13px; fill: #000; text-anchor: middle; }
+  </style>
+  <rect x="0" y="0" width="116" height="308" fill="#ffffff"/>
+
+  <g>
+    <title>Entradas T y F hacia la primera compuerta O</title>
+    <circle class="input" cx="62" cy="16" r="11"/>
+    <text x="62" y="16" dy=".35em">T</text>
+    <circle class="input" cx="96" cy="16" r="11"/>
+    <text x="96" y="16" dy=".35em">F</text>
+    <line class="wire" x1="62" y1="28" x2="62" y2="40" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="96" y1="28" x2="96" y2="40" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="48" y="46" width="62" height="24"/>
+    <text x="79" y="58" dy=".35em">O</text>
+  </g>
+
+  <g>
+    <title>Compuerta NO aplicada a la salida de la primera compuerta O</title>
+    <line class="wire" x1="79" y1="71" x2="79" y2="82" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="51" y="88" width="56" height="24"/>
+    <text x="79" y="100" dy=".35em">NO</text>
+  </g>
+
+  <g>
+    <title>Entradas T y F hacia la segunda compuerta O</title>
+    <circle class="input" cx="17" cy="134" r="11"/>
+    <text x="17" y="134" dy=".35em">T</text>
+    <circle class="input" cx="51" cy="134" r="11"/>
+    <text x="51" y="134" dy=".35em">F</text>
+    <line class="wire" x1="17" y1="146" x2="17" y2="158" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="51" y1="146" x2="51" y2="158" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="5" y="164" width="58" height="24"/>
+    <text x="34" y="176" dy=".35em">O</text>
+  </g>
+
+  <g>
+    <title>Compuerta Y que combina la segunda compuerta O y la compuerta NO</title>
+    <line class="wire" x1="34" y1="189" x2="34" y2="222" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="79" y1="112" x2="79" y2="222" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="12" y="228" width="82" height="24"/>
+    <text x="53" y="240" dy=".35em">Y</text>
+  </g>
+
+  <g>
+    <title>La compuerta Y reporta la salida</title>
+    <line class="wire" x1="53" y1="253" x2="53" y2="272" marker-end="url(#lgqa-arrow)"/>
+    <text x="53" y="294">Salida</text>
+  </g>
+</svg>

--- a/img/6-computers/logic-gates-quiz-a.svg
+++ b/img/6-computers/logic-gates-quiz-a.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="308" viewBox="0 0 116 308" role="img" aria-labelledby="lgqa-title lgqa-desc">
+  <title id="lgqa-title">Logic gate diagram of ((T or F) and (not (T or F)))</title>
+  <desc id="lgqa-desc">Inputs T and F feed an OR gate whose output feeds a NOT gate. A second pair of inputs, T and F, feeds a second OR gate. The outputs of the NOT gate and of the second OR gate both feed an AND gate, which produces the output.</desc>
+  <defs>
+    <marker id="lgqa-arrow" markerWidth="8" markerHeight="8" refX="4.5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#000"/>
+    </marker>
+  </defs>
+  <style>
+    .wire { stroke: #000; stroke-width: 1.5; fill: none; }
+    .box { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    .input { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    text { font-family: 'Courier New', Courier, monospace; font-weight: bold; font-size: 13px; fill: #000; text-anchor: middle; }
+  </style>
+  <rect x="0" y="0" width="116" height="308" fill="#ffffff"/>
+
+  <g>
+    <title>Inputs T and F into the first OR gate</title>
+    <circle class="input" cx="62" cy="16" r="11"/>
+    <text x="62" y="16" dy=".35em">T</text>
+    <circle class="input" cx="96" cy="16" r="11"/>
+    <text x="96" y="16" dy=".35em">F</text>
+    <line class="wire" x1="62" y1="28" x2="62" y2="40" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="96" y1="28" x2="96" y2="40" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="48" y="46" width="62" height="24"/>
+    <text x="79" y="58" dy=".35em">OR</text>
+  </g>
+
+  <g>
+    <title>NOT gate applied to the first OR gate's output</title>
+    <line class="wire" x1="79" y1="71" x2="79" y2="82" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="51" y="88" width="56" height="24"/>
+    <text x="79" y="100" dy=".35em">NOT</text>
+  </g>
+
+  <g>
+    <title>Inputs T and F into the second OR gate</title>
+    <circle class="input" cx="17" cy="134" r="11"/>
+    <text x="17" y="134" dy=".35em">T</text>
+    <circle class="input" cx="51" cy="134" r="11"/>
+    <text x="51" y="134" dy=".35em">F</text>
+    <line class="wire" x1="17" y1="146" x2="17" y2="158" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="51" y1="146" x2="51" y2="158" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="5" y="164" width="58" height="24"/>
+    <text x="34" y="176" dy=".35em">OR</text>
+  </g>
+
+  <g>
+    <title>AND gate combining the second OR gate and the NOT gate</title>
+    <line class="wire" x1="34" y1="189" x2="34" y2="222" marker-end="url(#lgqa-arrow)"/>
+    <line class="wire" x1="79" y1="112" x2="79" y2="222" marker-end="url(#lgqa-arrow)"/>
+    <rect class="box" x="12" y="228" width="82" height="24"/>
+    <text x="53" y="240" dy=".35em">AND</text>
+  </g>
+
+  <g>
+    <title>The AND gate reports the output</title>
+    <line class="wire" x1="53" y1="253" x2="53" y2="272" marker-end="url(#lgqa-arrow)"/>
+    <text x="53" y="294">output</text>
+  </g>
+</svg>

--- a/img/6-computers/logic-gates-quiz-b.es.svg
+++ b/img/6-computers/logic-gates-quiz-b.es.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="308" viewBox="0 0 116 308" role="img" aria-labelledby="lgqb-title lgqb-desc">
+  <title id="lgqb-title">Diagrama de compuertas lógicas de ((no (T y F)) o (T y F))</title>
+  <desc id="lgqb-desc">Las entradas T y F alimentan una compuerta Y cuya salida alimenta una compuerta NO. Un segundo par de entradas, T y F, alimenta una segunda compuerta Y. Las salidas de la compuerta NO y de la segunda compuerta Y alimentan una compuerta O, que produce la salida.</desc>
+  <defs>
+    <marker id="lgqb-arrow" markerWidth="8" markerHeight="8" refX="4.5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#000"/>
+    </marker>
+  </defs>
+  <style>
+    .wire { stroke: #000; stroke-width: 1.5; fill: none; }
+    .box { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    .input { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    text { font-family: 'Courier New', Courier, monospace; font-weight: bold; font-size: 13px; fill: #000; text-anchor: middle; }
+  </style>
+  <rect x="0" y="0" width="116" height="308" fill="#ffffff"/>
+
+  <g>
+    <title>Entradas T y F hacia la primera compuerta Y</title>
+    <circle class="input" cx="20" cy="16" r="11"/>
+    <text x="20" y="16" dy=".35em">T</text>
+    <circle class="input" cx="54" cy="16" r="11"/>
+    <text x="54" y="16" dy=".35em">F</text>
+    <line class="wire" x1="20" y1="28" x2="20" y2="40" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="54" y1="28" x2="54" y2="40" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="6" y="46" width="62" height="24"/>
+    <text x="37" y="58" dy=".35em">Y</text>
+  </g>
+
+  <g>
+    <title>Compuerta NO aplicada a la salida de la primera compuerta Y</title>
+    <line class="wire" x1="37" y1="71" x2="37" y2="82" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="9" y="88" width="56" height="24"/>
+    <text x="37" y="100" dy=".35em">NO</text>
+  </g>
+
+  <g>
+    <title>Entradas T y F hacia la segunda compuerta Y</title>
+    <circle class="input" cx="63" cy="134" r="11"/>
+    <text x="63" y="134" dy=".35em">T</text>
+    <circle class="input" cx="97" cy="134" r="11"/>
+    <text x="97" y="134" dy=".35em">F</text>
+    <line class="wire" x1="63" y1="146" x2="63" y2="158" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="97" y1="146" x2="97" y2="158" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="51" y="164" width="60" height="24"/>
+    <text x="81" y="176" dy=".35em">Y</text>
+  </g>
+
+  <g>
+    <title>Compuerta O que combina la compuerta NO y la segunda compuerta Y</title>
+    <line class="wire" x1="37" y1="112" x2="37" y2="222" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="81" y1="189" x2="81" y2="222" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="20" y="228" width="76" height="24"/>
+    <text x="58" y="240" dy=".35em">O</text>
+  </g>
+
+  <g>
+    <title>La compuerta O reporta la salida</title>
+    <line class="wire" x1="58" y1="253" x2="58" y2="272" marker-end="url(#lgqb-arrow)"/>
+    <text x="58" y="294">Salida</text>
+  </g>
+</svg>

--- a/img/6-computers/logic-gates-quiz-b.svg
+++ b/img/6-computers/logic-gates-quiz-b.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="308" viewBox="0 0 116 308" role="img" aria-labelledby="lgqb-title lgqb-desc">
+  <title id="lgqb-title">Logic gate diagram of ((not (T and F)) or (T and F))</title>
+  <desc id="lgqb-desc">Inputs T and F feed an AND gate whose output feeds a NOT gate. A second pair of inputs, T and F, feeds a second AND gate. The outputs of the NOT gate and of the second AND gate both feed an OR gate, which produces the output.</desc>
+  <defs>
+    <marker id="lgqb-arrow" markerWidth="8" markerHeight="8" refX="4.5" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#000"/>
+    </marker>
+  </defs>
+  <style>
+    .wire { stroke: #000; stroke-width: 1.5; fill: none; }
+    .box { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    .input { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    text { font-family: 'Courier New', Courier, monospace; font-weight: bold; font-size: 13px; fill: #000; text-anchor: middle; }
+  </style>
+  <rect x="0" y="0" width="116" height="308" fill="#ffffff"/>
+
+  <g>
+    <title>Inputs T and F into the first AND gate</title>
+    <circle class="input" cx="20" cy="16" r="11"/>
+    <text x="20" y="16" dy=".35em">T</text>
+    <circle class="input" cx="54" cy="16" r="11"/>
+    <text x="54" y="16" dy=".35em">F</text>
+    <line class="wire" x1="20" y1="28" x2="20" y2="40" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="54" y1="28" x2="54" y2="40" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="6" y="46" width="62" height="24"/>
+    <text x="37" y="58" dy=".35em">AND</text>
+  </g>
+
+  <g>
+    <title>NOT gate applied to the first AND gate's output</title>
+    <line class="wire" x1="37" y1="71" x2="37" y2="82" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="9" y="88" width="56" height="24"/>
+    <text x="37" y="100" dy=".35em">NOT</text>
+  </g>
+
+  <g>
+    <title>Inputs T and F into the second AND gate</title>
+    <circle class="input" cx="63" cy="134" r="11"/>
+    <text x="63" y="134" dy=".35em">T</text>
+    <circle class="input" cx="97" cy="134" r="11"/>
+    <text x="97" y="134" dy=".35em">F</text>
+    <line class="wire" x1="63" y1="146" x2="63" y2="158" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="97" y1="146" x2="97" y2="158" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="51" y="164" width="60" height="24"/>
+    <text x="81" y="176" dy=".35em">AND</text>
+  </g>
+
+  <g>
+    <title>OR gate combining the NOT gate and the second AND gate</title>
+    <line class="wire" x1="37" y1="112" x2="37" y2="222" marker-end="url(#lgqb-arrow)"/>
+    <line class="wire" x1="81" y1="189" x2="81" y2="222" marker-end="url(#lgqb-arrow)"/>
+    <rect class="box" x="20" y="228" width="76" height="24"/>
+    <text x="58" y="240" dy=".35em">OR</text>
+  </g>
+
+  <g>
+    <title>The OR gate reports the output</title>
+    <line class="wire" x1="58" y1="253" x2="58" y2="272" marker-end="url(#lgqb-arrow)"/>
+    <text x="58" y="294">output</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Replace legacy raster images with accessible SVGs

Converts three legacy raster images (`logic-gates-quiz-a.png`, `logic-gates-quiz-b.png`, `redundant-2.jpg`) to native SVG format with full accessibility support, and adds Spanish-language variants for all three diagrams.

## Changes

**New SVG assets (6 files):**
- `img/6-computers/logic-gates-quiz-a.svg` + `.es.svg` — logic gate diagrams redrawn at the same 116×308 footprint with real text, `<title>`/`<desc>` tags, and per-gate tooltips
- `img/6-computers/logic-gates-quiz-b.svg` + `.es.svg` — same treatment for the second quiz diagram
- `img/4-internet/redundant-2.svg` + `.es.svg` — network redundancy graph with 12 nodes and 19 verified links; Spanish variant uses Emisor/Receptor labels so Spanish pages no longer show English text

**Accessibility improvements:**
- All SVGs include internal `<title>` and `<desc>` elements readable by screen readers
- Quiz page alt text replaced with complete link-list descriptions (e.g., "Sender to A, Sender to B, …") so screen-reader users can answer the topology questions
- Network SVG includes progressive-enhancement hover/keyboard highlighting: focusing a node dims unrelated nodes and edges (no-ops inside `<img>` embeds)
- Fixed "multiple notes" typo in existing alt text

**HTML updates (11 files):**
- `2-network-redundancy.html` / `.es.html` — updated image references and detailed alt text on both quiz questions
- `unit-4-self-check.html` / `.es.html` — same
- `1-what-is-internet.html` / `.es.html` — updated image reference
- `09-digital-logic-gates.html` / `.es.html` — updated image references
- `unit-6-self-check.html` / `.es.html` — updated image references
- `1-reliable-communication.html` (teaching guide) — updated image reference

## Visual Changes

- [Logic gates A — original vs. new EN vs. new ES](https://www.superconductor.com/ticket_implementations/9MPGChBHDNLD/artifacts/8LB9MqLrkWGN)
- [Logic gates B — original vs. new EN vs. new ES](https://www.superconductor.com/ticket_implementations/9MPGChBHDNLD/artifacts/gbmCpwhHCpGD)
- [Network diagram — original vs. new EN vs. new ES](https://www.superconductor.com/ticket_implementations/9MPGChBHDNLD/artifacts/GtnNBcLc8KHr)

> **Note:** Original raster files are kept in place since archived `old/` pages still reference them.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/tM7RBtfTkfqg/implementations/9MPGChBHDNLD) | [App Preview](https://www.superconductor.com/tickets/tM7RBtfTkfqg/implementations/9MPGChBHDNLD/preview) | [Guided Review](https://www.superconductor.com/tickets/tM7RBtfTkfqg/implementations/9MPGChBHDNLD?tab=guided_review)

<!-- created-by-superconductor -->